### PR TITLE
refine toolbox.adoc

### DIFF
--- a/modules/ROOT/pages/toolbox.adoc
+++ b/modules/ROOT/pages/toolbox.adoc
@@ -1,82 +1,149 @@
 = Toolbox
----------
 
-[[toolbox-intro]]
-Introduction
-------------
+Toolbox makes it easy to use a containerized environment for everyday software 
+development and debugging.
 
-Modern development workflows increasingly rely on containers.
-In particular, on an immutable OS like Silverblue, containers
-are essential to getting work done.
+On immutable operating systems, like
+https://silverblue.fedoraproject.org/[Fedora Silverblue], toolbox 
+provides a familiar package-based environment in which tools and libraries can 
+be installed and used. However, toolbox can also be used standard package-based 
+systems too.
 
-But setting up containers 'by hand' can be annoying and repetitive.
-Fedora comes with a tool called toolbox that aims to make container
-setup painless and easy.
 
-You should consider using toolbox if you want to take advantage
-of an immutable, stable OS, but are ont willing to give up the
-convenience of dnf for package installation.
+[[toolbox-why-use]]
+== Why use toolbox?
 
-You should also conider using toolbox if you want to cleanly
-separate setups for different project, using different tools, or
-different versions of the same tools.
+Using toolbox containers to install development tools offers a number of 
+advantages:
+
+- It keeps the host OS clean and stable, and helps to avoid the clutter that 
+can happen after installing lots of development tools and packages.
+- Containers are a safe space to experiment: if things go wrong, it's easy to 
+throw a toolbox away and start again. 
+- Containers are a good way to isolate and organise the dependencies needed for 
+different projects.
+
+[[toolbox-how-it-works]]
+## How it works
+
+Toolbox takes the work out of using containers, by providing a small number of 
+simple commands to  create, enter, list and remove containers. It also 
+integrates toolbox containers into your regular working environment, to 
+make it easy for you to use them as an everyday development space.
+
+Each toolbox container is an environment that you can enter from the command 
+line. Inside it, you will find:
+
+- Your existing username and permissions
+- Access to your home directory
+- Common command lines tools, including the DNF package manager
+
+In other words, toolbox containers look, feel and behave like a standard Linux 
+command line environment.
+
+In most cases, when a command is run inside a container, the program from 
+inside the container is used. However, there are a few special cases where the 
+program on the host is used instead. One example of this is the toolbox command 
+itself. This makes it possible to use toolbox command from inside toolbox 
+containers.
 
 [[toolbox-installation]]
-Installation
-------------
+== Installation
 
-If you are using Fedora Silverblue 30 or newer, it comes with the 
-toolbox package preinstalled. If you are on a different version or
-edition of Fedora, the command
+=== Fedora Silverblue
 
-`dnf install toolbox`
+Toolbox is preinstalled on Fedora Silverblue 30 or newer. On older versions, it 
+can be installed with the following command:
 
-is sufficient to install the toolbox and it dependencies. If you
-are on an older version of Silverblue, use the command
+`$ rpm-ostree install toolbox`
 
-`rpm-ostree install toolbox`
+This will install toolbox as a layered RPM.
 
-to install the toolbox as a layered rpm.
+=== Fedora Workstation
+
+Toolbox can be installed on Fedora Workstation (or any package-based version of 
+Fedora) with the following command:
+
+`$ dnf install toolbox`
+
+[[toolbox-first-toolbox]]
+## Your first toolbox
+
+Once toolbox is installed, two simple commands are required to get started:
+
+`$ toolbox create`
+
+This will download an OCI image and create a toolbox container from it. Once 
+this is complete, run:
+
+`$ toolbox enter`
+
+Once inside the toolbox, you can access common command line tools, and install 
+new ones using DNF. 
+
+[NOTE]
+When the prompt is inside a toolbox, it is appended with a diamond: 
+this indicates that the prompt is inside a toolbox container.
 
 [[toolbox-commands]]
-Commands
---------
+== Commands and usage
 
-The toolbox comes with man pages for its commands. Here is a
-quick overview of the available commands:
+=== `toolbox create [--container <name>]`
 
-- `toolbox create` creates a new toolbox container
-- `toolbox enter` spawns a hell inside an existing container
-- `toolbox list` lists existing toolbox containers and images
-- `toolbox rm` removes one or more toolbox containers
-- `toolbox rmi` removes one or more toolbox images
+Creates a toolbox container. This will download an OCI image if one isn't 
+available (this is required to create the container). By default a Fedora image 
+matching the version of the host is used.
 
-All the commands understand a `--help` option.
+Used without options, `toolbox create` will automatically name the container it 
+creates. To create additional toolboxes, use the  ``--container <name>`` option 
+to give create a toolbox with a specified name.
 
-[[toolbox-boxes]]
-Available toolboxes
--------------------
+  
+=== `toolbox enter [--container <name>]`
 
-Before you can use the toolbox, you need to create a container.
-This requires downloading the base image (which can be big).
+Enters a toolbox for interactive use. Used without options, `toolbox enter` 
+opens the default toolbox. If there is more than one toolbox, use the 
+`--container name` option to specify a named toolbox to open.
 
-To make the seamless integration with the rest of the system
-work, the toolbox requires the use of a base image that has
-certain required components installed. 
+=== `toolbox list`
 
-The following base images are available:
-- fedora-29: built from Fedora 29 packages
-- fedora-30: built from Fedora 30 packages
-- fedora-31: built from Fedora 31 packages
+Lists local toolbox images and containers.
+
+[NOTE]
+It is normal to see two images listed, one with a localhost prefix and one with 
+a registry.fedoraproject.org prefix. These are a normal result of the toolbox 
+creation process.
+
+=== `toolbox rm [--force] <name>`
+
+Removes one or more toolbox containers. The `--force` option removes the 
+container even if it is running.
+
+=== `toolbox rmi [--force] <name>`
+
+Removes one or more toolbox images.
+
+=== Exiting the toolbox
+
+To return to the host environment, either run `exit` or quit the current shell 
+(typically Ctrl+D).
+
+[[toolbox-under-the-hood]]
+== Under the hood
+
+Toolbox uses the following technologies:
+
+ - https://buildah.io/[Buildah]
+ - https://www.opencontainers.org/[OCI container images]
+ - https://podman.io/[Podman]
 
 [[toolbox-contact]]
-Learn more
-----------
+== Contact and issues
 
-To learn more about the toolbox, to report issues you find, or
-to contribute ideas or patches,
-go to the http://github.com/debarshiray/toolbox[github] project.
+To report issues, make suggestions, or contribute fixes, see 
+https://github.com/debarshiray/toolbox[toolbox's GitHub project].
 
-To get in touch with toolbox users and developers, find us
-on the Fedora project discourse server, or join the `#silverblue`
-irc channel on freenode.
+To get in touch with toolbox users and developers, use 
+https://discussion.fedoraproject.org/[Fedora's Discourse 
+instance], or join the #silverblue IRC 
+channel on Freenode.


### PR DESCRIPTION
This is a rewrite of the toolbox docs, but I've tried to incorporate points and material from the original.

Main goals: add more detail and refinement. Cover all the essential information that a new user might need, particularly one who isn't very familiar with the Linux command line.