### PR TITLE
Fix podman adoc formatting

### DIFF
--- a/modules/ROOT/pages/toolbox.adoc
+++ b/modules/ROOT/pages/toolbox.adoc
@@ -3,7 +3,7 @@
 
 As an immutable host, Silverblue is an excellent platform for container-based 
 development and, for working with containers, https://buildah.io/[buildah] and 
-podman[https://podman.io/] are recommended.
+https://podman.io/[podman] are recommended.
 
 Silverblue also comes with the _toolbox_ utility, which uses containers to 
 provide an environment where development tools and libraries can be installed 


### PR DESCRIPTION
The adoc link for podman was reversed, flip it to properly link to podman.io but only display 'podman'