### PR TITLE
Add extra installation workaround to troubleshooting.adoc

### DIFF
--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -153,13 +153,15 @@ Users have reported that they cannot install Silverblue on an EFI based
 system where they previously had another OS installed.  The error that
 is often observed looks like:
 
-`ostree ['admin', '--sysroot=/mnt/sysimage', 'deploy', '--os=fedora-workstation', 'fedora-workstation:fedora/28/x86_64/workstation'] existed with code -6`
+----
+ostree ['admin', '--sysroot=/mnt/sysimage', 'deploy', '--os=fedora-workstation', 'fedora-workstation:fedora/28/x86_64/workstation'] existed with code -6`
+----
 
-A workaround for this issue is to reformat the EFI partition on the host
-during the install process.  This can be done during the install process
-by selecting Custom Partitioning and being sure to check the `Reformat`
-box when creating the `/boot/efi` partition.
+A couple of possible workarounds exist:
+
+* During the install process, select "Custom Partitioning" and create an additional EFI partition. Assign the newly created EFI partition to `/boot/efi`. You will then be able to boot the previous OS(s) alongside Fedora Silverblue. If this workaround is not successfull follow the below step.
+* Reformat the EFI partition on the host during the install process. This can be done by selecting "Custom Partitioning" and checking the `Reformat` box when creating the `/boot/efi` partition.
 
 WARNING: Choosing to reformat `/boot/efi` will likely result in the inability
-to boot any other operating systems that were previously installed.  Be sure that
-yau have backed up any important data before using this workaround.
+to boot any other operating systems that were previously installed. Be sure that
+you have backed up any important data before using this workaround.


### PR DESCRIPTION
Workaround related to installation failures when pre existing EFI partition
is found