### PR TITLE
Add a section on resetting toolbox permissions

### DIFF
--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -163,3 +163,15 @@ box when creating the `/boot/efi` partition.
 WARNING: Choosing to reformat `/boot/efi` will likely result in the inability
 to boot any other operating systems that were previously installed.  Be sure that
 yau have backed up any important data before using this workaround.
+
+Unable to enter a toolbox due to permissions errors
+----------------------------------------------------
+https://github.com/containers/libpod/issues/3187
+
+With certain versions of `libpod`, trying to enter a toolbox will result in
+errors. You can fix this by resetting the permissions on the overlay-containers
+with the following command.
+
+`sudo chown -R $USER ~/.local/share/containers/storage/overlay-containers`
+
+This will reset the permissions on your containers and allow you to enter them again.


### PR DESCRIPTION
A while back I ran into an error with toolbox where I could not enter it due to faulty permissions. This may be fixed in newer versions of libpod already, I have not had the same error since the first time, but just in case someone encounters a similar issue this may help them resolve the issue. Credit goes to refi64 on discussion.fedoraproject.org for suggesting this solution that fixed the problem when I encountered it.