### PR TITLE
Add `contributing.adoc` and update `nav.adoc`

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,3 +1,4 @@
+* xref:contributing.adoc[Contributing]
 * xref:installation.adoc[Installation]
 * xref:getting-started.adoc[Getting Started]
 * xref:updates-upgrades-rollbacks.adoc[Updates, Upgrades & Rollbacks]

--- a/modules/ROOT/pages/contributing.adoc
+++ b/modules/ROOT/pages/contributing.adoc
@@ -1,0 +1,42 @@
+[[contributing]]
+= Contributing to Fedora Silverblue
+
+Help us improve Fedora Silverblue by contributing to the project!
+
+[[developing]]
+== Developing Silverblue
+
+If you are a developer, you can contribute to one of the several projects which make Fedora Silverblue possible. Submit your pull requests to:
+
+* https://github.com/projectatomic/rpm-ostree[rpm-ostree]
+* https://github.com/flatpak/flatpak[flatpak]
+* https://github.com/ostreedev/ostree[ostree]
+* https://github.com/debarshiray/toolbox[toolbox]
+* https://github.com/containers/libpod[podman]
+
+Your contributions towards the main https://fedoraproject.org/wiki/Join[Fedora] project are also very welcome.
+
+[[writing-documentation]]
+== Writing Documentation
+
+Creating or modifing documentation is easy. Head over to our https://github.com/fedora-silverblue/silverblue-docs[documentation] GitHub repository, fork it and create a pull request.
+
+If you are not comfortable with using git, create a new topic in our https://discussion.fedoraproject.org/c/desktop/silverblue[community] or log an https://github.com/fedora-silverblue/silverblue-docs/issues[issue] describing what need to be changed.
+
+[[writing-conventions]]
+=== Writing Conventions
+
+When creating documentation, please follow these writing conventions:
+
+* Code blocks for commands that require `root` privileges must show the `#` prompt symbol. Example:
+
+ # dnf install <package>
++
+The `$` user prompt symbol can also be used but you must prefix the command with `sudo`. Example:
+
+ $ sudo dnf install <package>
+
+[[reporting-issues]]
+== Reporting Issues
+
+You can report bugs and suggest features or improvements on the https://github.com/fedora-silverblue/issue-tracker/issues[issue tracker.]


### PR DESCRIPTION
Created a contributing page with an initial set of conventions.
There is some overlapping with https://silverblue.fedoraproject.org/contribute
but I think the Docs pages are easier to update and are the right place for the contributing section.