### PR TITLE
Add `podman` for build and preview

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,41 @@
 #!/bin/sh
 
-if [ "$(uname)" == "Darwin" ]; then
+cmd="run --rm -it -v $(pwd):/antora:z docker.io/antora/antora --html-url-extension-style=indexify site.yml"
+
+container_launch() {
+    # Use podman if available on Linux, otherwise use docker
+    if hash podman 2>/dev/null; then
+        echo "This build script is using Podman to run the build in an isolated environment."
+        podman $1
+
+    elif hash docker 2>/dev/null; then
+
+        if groups | grep -wq "docker"; then
+            echo "This build script is using Docker to run the build in an isolated environment."
+            docker $1
+        
+        else
+            echo "This build script is using $runtime to run the build in an isolated environment. You might be asked for your password."
+            echo "You can avoid this by adding your user to the 'docker' group, but be aware of the security implications. See https://docs.docker.com/install/linux/linux-postinstall/."
+            sudo docker $1
+        fi
+
+    else
+   	echo "Error: No container runtimes were found."
+	echo "Please install either podman or docker"
+	exit 1
+    fi
+}
+
+if [ "$(uname)" = "Darwin" ]; then
     # Running on macOS.
     # Let's assume that the user has the Docker CE installed
     # which doesn't require a root password.
-    docker run --rm -it -v $(pwd):/antora antora/antora --html-url-extension-style=indexify site.yml
+    echo "This build script is using Docker container runtime to run the build in an isolated environment."
+    docker run $cmd
 
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
     # Running on Linux.
-    # Let's assume that it's running the Docker deamon
-    # which requires root.
-    echo ""
-    echo "This build script is using Docker to run the build in an isolated environment. You might be asked for a root password in order to start it."
-sudo docker run --rm -it -v $(pwd):/antora:z antora/antora --html-url-extension-style=indexify site.yml
+    # Build the documentation using the container_launch function
+    container_launch "$cmd"
 fi

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,14 @@
+server {
+    listen       80;
+    server_name  localhost;
+    
+    location / {
+        root   /antora/public;
+        index  index.html index.htm;
+    }
+ 
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/preview.sh
+++ b/preview.sh
@@ -1,18 +1,47 @@
 #!/bin/sh
 
-if [ "$(uname)" == "Darwin" ]; then
+cmd="run --rm -v $(pwd):/antora:ro -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p 8080:80 nginx"
+
+container_launch() {
+    # Use podman if available on Linux, otherwise use docker
+    if hash podman 2>/dev/null; then
+        echo "Podman is launching the preview."
+        echo "The preview will be available at http://localhost:8080/"
+        podman $1
+
+    elif hash docker 2>/dev/null; then
+    
+	if groups | grep -wq "docker"; then
+            echo "Docker is launching the preview in an isolated environment."
+	    echo "The preview will be available at http://localhost:8080/"
+            docker $1
+
+        else
+            echo "This preview script is using $runtime to run the preview in an isolated environment. You might be asked for your password."
+            echo "You can avoid this by adding your user to the 'docker' group, but be aware of the security implications. See https://docs.docker.com/install/linux/linux-postinstall/."
+	    echo "The preview will be available at http://localhost:8080/"
+            sudo docker $1
+        fi
+
+    else
+        echo "Error: No container runtimes were found."
+        echo "Please install either podman or docker"
+        exit 1
+    fi
+}
+
+if [ "$(uname)" = "Darwin" ]; then
     # Running on macOS.
     # Let's assume that the user has the Docker CE installed
     # which doesn't require a root password.
-    echo "The preview will be available at http://localhost:8080/"
-    docker run --rm -v $(pwd)/public:/usr/share/nginx/html:ro -p 8080:80 nginx
-
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    # Running on Linux.
-    # Let's assume that it's running the Docker deamon
-    # which requires root.
     echo ""
-    echo "This build script is using Docker to run the build in an isolated environment. You might be asked for a root password in order to start it."
     echo "The preview will be available at http://localhost:8080/"
-    sudo docker run --rm -v $(pwd)/public:/usr/share/nginx/html:ro -p 8080:80 nginx
+    echo ""
+    docker "$cmd"
+
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
+    # Running on Linux.
+    # Run the preview using the container_launch function
+    echo ""
+    container_launch "$cmd"
 fi


### PR DESCRIPTION
Pushing again as I had messed up my fork. Sorry.

This commit also brings this repo structure (more) in lne with Fedora Docs template repo (see #42 which this PR is meant to close)

Tested on FSB30 and Ubuntu 19.04
A test on Mac would be appreciated.

Thanks!