### PR TITLE
suppress indentation warning

### DIFF
--- a/modules/ROOT/pages/reading-and-resources.adoc
+++ b/modules/ROOT/pages/reading-and-resources.adoc
@@ -7,20 +7,20 @@ This page is a list of further reading and resources for Silverblue.
 * https://buildah.io/[Buildah] - build OCI container images
 * http://flatpak.org[Flatpak] - next-generation desktop app framework
 * https://ostree.readthedocs.io/en/latest/[ostree] - OS image composition 
-and updates
+  and updates
 * https://podman.io/[podman] - daemonless container engine
 * https://rpm-ostree.readthedocs.io/en/latest/[rpm-ostree] - hybrid 
-image/package system
+  image/package system
 
 == Documents
 
 * link:{attachmentsdir}/team-silverblue-origins.pdf[Team Silverblue - The
-Origins] - PDF that explains the motivations, goals, and history behind
-Silverblue
+  Origins] - PDF that explains the motivations, goals, and history behind
+  Silverblue
 * link:{attachmentsdir}/flatpak-print-cheatsheet.pdf[Flatpak Cheat Sheet] - 
-PDF with common flatpak commands
+  PDF with common flatpak commands
 * link:{attachmentsdir}/silverblue-cheatsheet.pdf[rpm-ostree Cheat Sheet] - PDF 
-with common rpm-ostree commands
-*  link:{attachmentsdir}/container-commandos.pdf[Container commandos] -  a 
-playful introduction to tools such as podman, cri-o and buildah by Máirín Duffy 
-and Dan Walsh. Print it out, and learn as you color!
+  with common rpm-ostree commands
+* link:{attachmentsdir}/container-commandos.pdf[Container commandos] -  a
+  playful introduction to tools such as podman, cri-o and buildah by Máirín Duffy
+  and Dan Walsh. Print it out, and learn as you color!

--- a/modules/ROOT/pages/toolbox.adoc
+++ b/modules/ROOT/pages/toolbox.adoc
@@ -22,11 +22,11 @@ Using toolbox containers to install development tools offers a number of
 advantages:
 
 * It keeps the host OS clean and stable, and helps to avoid the clutter that 
-can happen after installing lots of development tools and packages.
+  can happen after installing lots of development tools and packages.
 * Containers are a safe space to experiment: if things go wrong, it's easy to 
-throw a toolbox away and start again. 
+  throw a toolbox away and start again.
 * Containers are a good way to isolate and organise the dependencies needed for 
-different projects.
+  different projects.
 
 [[toolbox-how-it-works]]
 == How it works

--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -57,10 +57,10 @@ work the same way for both), as well as for development purposes.
 There are two ways to roll back to the previous version:
 
 . Temporary rollbacks: to temporarily roll back to a previous version, simply 
-reboot and select the previous version from the boot menu (often known as the 
-grub menu).
+  reboot and select the previous version from the boot menu (often known as the
+  grub menu).
 . Permanent rollbacks: to permanently switch back to the previous deployment,
-use the `rpm-ostree rollback` command.
+  use the `rpm-ostree rollback` command.
 
 After rolling back, you will technically be on an old OS version, and may be 
 prompted to update. Updating will undo the rollback, so should be avoided if 


### PR DESCRIPTION
missing spaces creates warning in Fedora docs internationalization system, preventing us to find real generation issues