### PR TITLE
Add clarification regarding which directories are read-only

### DIFF
--- a/modules/ROOT/pages/technical-information.adoc
+++ b/modules/ROOT/pages/technical-information.adoc
@@ -40,15 +40,14 @@ system directories and everything below them are read-only:
 * `/`
 * `/usr`
 
-On the otherhand, the following system directories are writable using the live filesystem:
+On the otherhand, the following system directories are writable:
+
+* `/etc`
+* `/var`
+The following system directories are writable, but expect to become read-only in future versions of Silverblue:
 
 * `/boot`
-* `/dev`
-* `/etc`
-* `/run`
 * `/sysroot`
-* `/tmp`
-* `/var`
 
 `/var` is where the majority of Silverblue's runtime state is stored. Symlinks are used 
 to make traditional state-carrying directories available in their expected 

--- a/modules/ROOT/pages/technical-information.adoc
+++ b/modules/ROOT/pages/technical-information.adoc
@@ -34,10 +34,23 @@ whenever you update the base OS image.
 [[filesystem-layout]]
 == Silverblue filesystem layout
 
-On Silverblue, the root filesystem is immutable. This means that `/`, `/usr` 
-and everything below it is read-only.
+On Silverblue, the root filesystem is immutable. This means that the following 
+system directories and everything below them are read-only:
 
-`/var` is where all of Silverblue's runtime state is stored. Symlinks are used 
+* `/`
+* `/usr`
+
+On the otherhand, the following system directories are writable using the live filesystem:
+
+* `/boot`
+* `/dev`
+* `/etc`
+* `/run`
+* `/sysroot`
+* `/tmp`
+* `/var`
+
+`/var` is where the majority of Silverblue's runtime state is stored. Symlinks are used 
 to make traditional state-carrying directories available in their expected 
 locations. This includes:
 


### PR DESCRIPTION
The current implementation of the docs suggest that a couple directories, like /etc, are read-only. I wanted to get this clarified in the docs; i tried to be more specific about which are read-only and which are not. If you have any suggestions/corrections for this pull-request, let me know.