### PR TITLE
Update links to OSTree and rpm-ostree documentation

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -134,4 +134,4 @@ You may also use `override remove` to effectively "hide" packages; they will sti
 
 Removing and replacing packages using package layering is not generally 
 recommended. For more information, see the 
-https://rpm-ostree.readthedocs.io/en/latest/manual/administrator-handbook/[rpm-ostree documentation].
+https://coreos.github.io/rpm-ostree/administrator-handbook/[rpm-ostree documentation].

--- a/modules/ROOT/pages/reading-and-resources.adoc
+++ b/modules/ROOT/pages/reading-and-resources.adoc
@@ -6,10 +6,10 @@ This page is a list of further reading and resources for Silverblue.
 
 * https://buildah.io/[Buildah] - build OCI container images
 * http://flatpak.org[Flatpak] - next-generation desktop app framework
-* https://ostree.readthedocs.io/en/latest/[ostree] - OS image composition 
+* https://ostreedev.github.io/ostree/[ostree] - OS image composition 
   and updates
 * https://podman.io/[podman] - daemonless container engine
-* https://rpm-ostree.readthedocs.io/en/latest/[rpm-ostree] - hybrid 
+* https://coreos.github.io/rpm-ostree/[rpm-ostree] - hybrid 
   image/package system
 
 == Documents

--- a/modules/ROOT/pages/technical-information.adoc
+++ b/modules/ROOT/pages/technical-information.adoc
@@ -12,7 +12,7 @@ in a non-standard manner.
 [[ostree-rpm-ostree]]
 == ostree and rpm-ostree
 
-https://ostree.readthedocs.io/en/latest/[ostree] is the core technology that is 
+https://ostreedev.github.io/ostree/[ostree] is the core technology that is 
 used to compose, deploy and update Silverblue. ostree operates in a similar 
 manner to a version control system, but it operates on entire filesystem trees. 
 It is often described as “Git for operating system binaries”.
@@ -21,7 +21,7 @@ For Silverblue installs, ostree is responsible for deploying and updating the OS
 image (including everything below `/` that is not symlinked into `/var`). It 
 also updates `grub.cfg` entries to point to the current image.
 
-https://rpm-ostree.readthedocs.io/en/latest/[rpm-ostree] builds on top of 
+https://coreos.github.io/rpm-ostree/[rpm-ostree] builds on top of 
 ostree, and makes it possible to install RPMs as a “layer” on top of an ostree 
 image. This makes it possible to install RPMs on Silverblue.
 

--- a/modules/ROOT/pages/technical-information.adoc
+++ b/modules/ROOT/pages/technical-information.adoc
@@ -53,5 +53,5 @@ This means that separate home partitions should be mounted on `/var/home`.
 
 For a more detailed explanation of Silverblue's filesystem layout, refer to the 
 excellent 
-https://ostree.readthedocs.io/en/latest/manual/adapting-existing/[libostree 
+https://ostreedev.github.io/ostree/adapting-existing/[libostree 
 documentation].


### PR DESCRIPTION
Both OSTree and rpm-ostree have moved their documentation hosting to GitHub from readthedocs.io. While the links referring to the home pages still work via a redirect the ones referring to a specific page end up returning a 404, so this fixes that while also skipping the redirect for the links that still work.