### PR TITLE
Update technical-information.adoc to include /etc in the filesystem layout description.

### DIFF
--- a/modules/ROOT/pages/technical-information.adoc
+++ b/modules/ROOT/pages/technical-information.adoc
@@ -35,7 +35,9 @@ whenever you update the base OS image.
 == Silverblue filesystem layout
 
 On Silverblue, the root filesystem is immutable. This means that `/`, `/usr` 
-and everything below it is read-only.
+and almost everything below it is read-only.
+
+`/etc` is not part of the immutable OS image and is a regular writable directory.
 
 `/var` is where all of Silverblue's runtime state is stored. Symlinks are used 
 to make traditional state-carrying directories available in their expected 


### PR DESCRIPTION
Having never used Silverblue, the over simplified description of the filesystem layout left me puzzled.  Added a line of info on /etc taken from the Silverblue FAQ page and the Deployments page on ostreedev.