### PR TITLE
Added section for a multiboot partition scheme

### DIFF
--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -77,4 +77,15 @@ with partitions for `/boot`, `/`, `swap` and `/var/home`.
 
 Manual partitioning on Silverblue can be done with `Btrfs`,
 https://en.wikipedia.org/wiki/Logical_Volume_Manager_%28Linux%29[LVM], as well 
-as standard partitions or an `xfs` filesystem.  
+as standard partitions or an `xfs` filesystem.
+
+[[manual-partition-multiboot]]
+=== Manual Partitioning in a "multiboot" scheme
+
+Some users will want to install Silverblue alongside other operating systems -- including or *NIX flavours. For them we provide a minimal, functional partition scheme, consisting of:
+
+1. `/boot/efi` on a (physical) partition -- typically the active ESP partition shared among bootloaders
+2. `/boot` on a (physical) partition, freshly created for the installation, preferably formatted to `btrfs`
+3. `/` -- root -- as a preferably `btrfs` (physical) partition within a freshly created LVM2 volume group.
+
+To reproduce the scheme from Anaconda (the installer), simply set the preexistent ESP partition to mount as `/boot/efi` (1), and see to it that (2) and (3) are created and set as above.

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -84,8 +84,8 @@ as standard partitions or an `xfs` filesystem.
 
 Some users will want to install Silverblue alongside other operating systems -- including or *NIX flavours. For them we provide a minimal, functional partition scheme, consisting of:
 
-1. `/boot/efi` on a (physical) partition -- typically the active ESP partition shared among bootloaders
-2. `/boot` on a (physical) partition, freshly created for the installation, preferably formatted to `btrfs`
-3. `/` -- root -- as a preferably `btrfs` (physical) partition within a freshly created LVM2 volume group.
+1. `/boot/efi` on a physical partition -- typically the active ESP partition shared among bootloaders
+2. `/boot` on a physical, freshly created partition, preferably formatted to `btrfs`
+3. `/` -- root -- as preferably `btrfs`-formatted physicial partition within a freshly created LVM2 volume group.
 
-To reproduce the scheme from Anaconda (the installer), simply set the preexistent ESP partition to mount as `/boot/efi` (1), and see to it that (2) and (3) are created and set as above.
+To reproduce the scheme from Anaconda (the installer), simply set the preexistent ESP partition to mount as `/boot/efi` (1) and see to it that (2) and (3) are created and set as above.


### PR DESCRIPTION
Added a "minimal functional" partition scheme for users seeking a multiboot environment while using little disk space.

_edited_: I am being told the `/boot` partition might not be necessary.  We can talk about it.