### PR TITLE
Remove Adobe Flash plugin related part from FAQ

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -47,18 +47,6 @@ How can I play more videos in Firefox, like YouTube?::
     available as a 
     https://firefox-flatpak.mojefedora.cz/org.mozilla.FirefoxNightly.flatpakref[Flatpak].
 
-How can I use Adobe Flash on the Firefox version pre installed on my system?::
-
-You can follow this https://docs.fedoraproject.org/en-US/quick-docs/using-adobe-flash/[Fedora quickdoc] with the following changes:
-
-. where needed, substitute the `dnf install` command with the `rpm-ostree install` command
-
-. reboot the system after the installation of the Adobe DNF repository
-
-. install only `flash-plugin` as `libcurl` and `alsa-plugins-pulseaudio` are installed by default on Fedora Silverblue
-
-. reboot the system after having installed `flash-plugin`
-
 How can I see what packages were updated between two commits?::
 
 * If you want to compare the booted deployment with the pending deployment (or rollback deployment), simply issue:


### PR DESCRIPTION
> This reverts commit 04006c39e19ae9174bb7aee53aabbf9d1a38747f.

Support of Adobe Flash [has ended](https://www.adobe.com/products/flashplayer/end-of-life.html). I guess it will be good to drop everything related to it from Fedora Docs? 😃