### PR TITLE
Fix typo in troubleshooting.adoc

### DIFF
--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -136,7 +136,7 @@ Users have reported that they cannot install Silverblue on an EFI based
 system where they previously had another OS installed.  The error that
 is often observed looks like:
 
- ostree ['admin', '--sysroot=/mnt/sysimage', 'deploy', '--os=fedora-workstation', 'fedora-workstation:fedora/28/x86_64/workstation'] existed with code -6`
+ ostree ['admin', '--sysroot=/mnt/sysimage', 'deploy', '--os=fedora-workstation', 'fedora-workstation:fedora/28/x86_64/workstation'] exited with code -6`
 
 A couple of possible workarounds exist:
 


### PR DESCRIPTION
existed -> exited, as can be seen in https://github.com/ostreedev/ostree/blob/15878c935a886a1a5d25b771c2cf68c7b1c01936/tests/test-concurrency.py#L64