### PR TITLE
Change description to use 'anti-hysteresis' instead of 'immutable'

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -4,9 +4,9 @@ Welcome to the Fedora Silverblue user guide!
 
 image::silverblue-logo.svg[Silverblue logo]
 
-_Fedora Silverblue_ is an immutable desktop operating system. It aims to be 
-extremely stable and reliable. It also aims to be an excellent platform for 
-developers and for those using container-focused workflows.
+_Fedora Silverblue_ is an extremely stable and reliable desktop oprating system. 
+It also aims to be an excellent platform for developers and for those using 
+container-focused workflows.
 
 [[introduction]]
 == Introduction to Silverblue
@@ -15,17 +15,17 @@ Silverblue is a variant of Fedora Workstation. It looks, feels and behaves like
 a regular desktop operating system, and the experience is similar to what you 
 find with using a standard Fedora Workstation.
 
-However, unlike other operating systems, Silverblue is immutable. This means 
-that every installation is identical to every other installation of the same 
-version. The operating system that is on disk is exactly the same from one 
-machine to the next, and it never changes as it is used.
+However, unlike other operating systems, Silverblue has reprovisionable 
+infrastructure with anti-hysteresis properties. This means that every 
+installation is identical to every other installation of the same version. The 
+operating system that is on disk is exactly the same from one machine to the 
+next, and it never changes as it is used.
 
-Silverblue's immutable design is intended to make it more stable, less prone to 
-bugs, and easier to test and develop. Finally, Silverblue's immutable design 
-also makes it an excellent platform for containerized applications as well as 
-container-based software development. In each case, applications (apps) and 
-containers are kept separate from the host system, improving stability and 
-reliability.
+Silverblue's design is intended to make it more stable, less prone to bugs, and 
+easier to test and develop. The design also makes it an excellent platform for 
+containerized applications as well as container-based software development. 
+In each case, applications (apps) and containers are kept separate from the 
+host system, improving stability and reliability.
 
 Silverblue's core technologies have some other helpful features. OS updates are 
 fast and there's no waiting around for them to install: just reboot as normal 

--- a/modules/ROOT/pages/toolbox.adoc
+++ b/modules/ROOT/pages/toolbox.adoc
@@ -1,9 +1,9 @@
 [[toolbox]]
 = Toolbox
 
-As an immutable host, Silverblue is an excellent platform for container-based
-development and, for working with containers, https://buildah.io/[buildah] and
-https://podman.io/[podman] are recommended.
+As a host system with anti-hysteresis properties, Silverblue is an excellent 
+platform for container-based development and, for working with containers, 
+https://buildah.io/[buildah] and https://podman.io/[podman] are recommended.
 
 Silverblue also comes with the https://github.com/containers/toolbox[toolbox]
 utility, which uses containers to provide an environment where development
@@ -13,7 +13,7 @@ tools and libraries can be installed and used.
 == Why use toolbox?
 
 Toolbox makes it easy to use a containerized environment for everyday software
-development and debugging. On immutable operating systems, like
+development and debugging. On anti-hysteresis operating systems, like
 https://silverblue.fedoraproject.org/[Fedora Silverblue], it provides a
 familiar package-based environment in which tools and libraries can be
 installed and used. However, toolbox can also be used on package-based systems.


### PR DESCRIPTION
Initiated by [Colin Walter's article](https://blog.verbum.org/2020/08/22/immutable-%e2%86%92-reprovisionable-anti-hysteresis/), I think it is time to change the description in the documentation. This is just my simple proposition of how to do it.