### PR TITLE
Update wiki links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+cache/
+public/

--- a/modules/ROOT/pages/contributing.adoc
+++ b/modules/ROOT/pages/contributing.adoc
@@ -23,7 +23,7 @@ Your favourite application is not in the default repository and won't probably b
 
 * https://docs.fedoraproject.org/en-US/flatpak/tutorial/[RPM to Flatpak tutorial]
 
-To become an official packager you need to go through several steps to gain all required permissions to use the Fedora infrastructure (Pagure, Koji, Bodhi). There is a detailed https://fedoraproject.org/wiki/Join_the_package_collection_maintainers[wiki page] about becoming a packager.
+To become an official packager you need to go through several steps to gain all required permissions to use the Fedora infrastructure (Pagure, Koji, Bodhi). There is a detailed https://docs.fedoraproject.org/en-US/package-maintainers/Joining_the_Package_Maintainers/[page] about becoming a packager.
 
 Other useful links:
 


### PR DESCRIPTION
Package Maintainer Docs have moved
from wiki to docs.fedoraproject.org.
Update links to point to the new location.