### PR TITLE
Collection of styling and other minor fixes

### DIFF
--- a/modules/ROOT/pages/contributing.adoc
+++ b/modules/ROOT/pages/contributing.adoc
@@ -6,7 +6,8 @@ Help us improve Fedora {variant-name} by contributing to the project!
 [[developing]]
 == Developing {variant-name}
 
-If you are a developer, you can contribute to one of the several projects which make Fedora {variant-name} possible. Submit your pull requests to:
+If you are a developer, you can contribute to one of the several projects which make Fedora {variant-name} possible.
+Submit your pull requests to:
 
 * https://github.com/projectatomic/rpm-ostree[rpm-ostree]
 * https://github.com/flatpak/flatpak[flatpak]
@@ -19,7 +20,8 @@ Your contributions towards the main https://fedoraproject.org/wiki/Join[Fedora] 
 [[writing-documentation]]
 == Writing Documentation
 
-Creating or modifying documentation is easy. Head over to our {docs-src}[documentation] GitHub repository, fork it and create a pull request.
+Creating or modifying documentation is easy.
+Head over to our {docs-src}[documentation] GitHub repository, fork it and create a pull request.
 
 If you are not comfortable with using git, create a new topic in our {discussion-forum}[community] or log an {docs-issue}[issue] describing what need to be changed.
 
@@ -28,11 +30,13 @@ If you are not comfortable with using git, create a new topic in our {discussion
 
 When creating documentation, please follow these writing conventions:
 
-* Code blocks for commands that require `root` privileges must show the `#` prompt symbol. Example:
+* Code blocks for commands that require `root` privileges must show the `#` prompt symbol.
+  Example:
 
  # dnf install <package>
 +
-The `$` user prompt symbol can also be used but you must prefix the command with `sudo`. Example:
+The `$` user prompt symbol can also be used but you must prefix the command with `sudo`.
+Example:
 
  $ sudo dnf install <package>
 
@@ -48,7 +52,8 @@ Your favourite application is not in the default repository and won't probably b
 
 * https://docs.fedoraproject.org/en-US/flatpak/tutorial/[RPM to Flatpak tutorial]
 
-To become an official packager you need to go through several steps to gain all required permissions to use the Fedora infrastructure (Pagure, Koji, Bodhi). There is a detailed https://docs.fedoraproject.org/en-US/package-maintainers/Joining_the_Package_Maintainers/[page] about becoming a packager.
+To become an official packager you need to go through several steps to gain all required permissions to use the Fedora infrastructure (Pagure, Koji, Bodhi).
+There is a detailed https://docs.fedoraproject.org/en-US/package-maintainers/Joining_the_Package_Maintainers/[page] about becoming a packager.
 
 Other useful links:
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -3,47 +3,38 @@
 == About the project
 
 Is it Team Silverblue, Silverblue, or Fedora Silverblue?::
-    We chose the name Team Silverblue to refer to the overall project. Fedora 
-    Silverblue will be used for the OS that we are producing, but calling it 
-    Silverblue in its short version is fine as well.
+    We chose the name Team Silverblue to refer to the overall project.
+    Fedora Silverblue will be used for the OS that we are producing, but calling it Silverblue in its short version is fine as well.
 
 Why does the Silverblue logo look like a leaf?::
-    Our favorite choice for a project name was Silverleaf, but that sadly did 
-    not work out. We just couldn't quite let go of the leaf. You could also say 
-    that Silverblue is a new leaf on Fedora's OSTree. 😀
+    Our favorite choice for a project name was Silverleaf, but that sadly did not work out.
+    We just couldn't quite let go of the leaf.
+    You could also say that Silverblue is a new leaf on Fedora's OSTree.
+    😀
 
 Is Silverblue another GNOME OS?::
-    GNOME OS was a codename that was used by the upstream GNOME project for a 
-    while to refer to the idea of designing the entire desktop user experience. 
-    By contrast, Silverblue is an effort inside the Fedora project, and will be 
-    built with existing Fedora technologies. However, the two efforts do share 
-    a desire to deliver a user experience that is polished and coherent.
+    GNOME OS was a codename that was used by the upstream GNOME project for a while to refer to the idea of designing the entire desktop user experience.
+    By contrast, Silverblue is an effort inside the Fedora project, and will be built with existing Fedora technologies.
+    However, the two efforts do share a desire to deliver a user experience that is polished and coherent.
 
 What is {variant-name}'s relationship with Project Atomic?::
-    Fedora {variant-name} uses the same core technology as Fedora Atomic Host (as
-    well as its successor, Fedora CoreOS). However, {variant-name} is specifically
-    focused on workstation/desktop use cases.
+    Fedora {variant-name} uses the same core technology as Fedora Atomic Host (as well as its successor, Fedora CoreOS).
+    However, {variant-name} is specifically focused on workstation/desktop use cases.
 
 == About using {variant-name}
 
 How can I install Eclipse on {variant-name}?::
-    Instructions to setup the Nightly flatpak remote for Eclipse are available
-    http://eclipse.matbooth.co.uk/flatpak[here].
+    Instructions to setup the Nightly flatpak remote for Eclipse are available http://eclipse.matbooth.co.uk/flatpak[here].
 
 How do I create a VPN connection?::
-    `/etc` is not part of the immutable OS image, so you can just copy files 
-    into `/etc/NetworkManager/system-connections` (or let NetworkManager store 
-    them there when you recreate your connections). Certificates in `/etc/pki` 
-    need to be handled similarly.
+    `/etc` is not part of the immutable OS image, so you can just copy files into `/etc/NetworkManager/system-connections` (or let NetworkManager store them there when you recreate your connections).
+    Certificates in `/etc/pki` need to be handled similarly.
 
 How can I play more videos in Firefox, like YouTube?::
-    Firefox is included in the OS image for now. Until that changes, getting it 
-    to play videos works the same way as it does for the regular Fedora 
-    Workstation: find a package with the needed codecs, and install it. The one 
-    difference is that you use `rpm-ostree install` instead of `dnf install`.
-    An alternative solution is to install the nightly Firefox, which is 
-    available as a 
-    https://firefox-flatpak.mojefedora.cz/org.mozilla.FirefoxNightly.flatpakref[Flatpak].
+    Firefox is included in the OS image for now.
+    Until that changes, getting it to play videos works the same way as it does for the regular Fedora Workstation: find a package with the needed codecs, and install it.
+    The one difference is that you use `rpm-ostree install` instead of `dnf install`.
+    An alternative solution is to install the nightly Firefox, which is available as a https://firefox-flatpak.mojefedora.cz/org.mozilla.FirefoxNightly.flatpakref[Flatpak].
 
 How can I see what packages were updated between two commits?::
 
@@ -71,7 +62,8 @@ You can simply use:
 
 How can I check if an `rpm` software package is available in the repository?::
 
-At this point in time, there is no `rpm` package search function built into `rpm-ostree`. However, you can use `toolbox` with the following command:
+At this point in time, there is no `rpm` package search function built into `rpm-ostree`.
+However, you can use `toolbox` with the following command:
 
  $ toolbox run dnf search <package>
 +
@@ -105,6 +97,7 @@ NOTE: `0` here refers to the first deployment listed by `rpm-ostree status`
 
 . After the deployment is pinned, you can upgrade your system by using the instructions found {docs-url}/updates-upgrades-rollbacks/#upgrading[here].
 
-. When you have completed rebasing, reboot the system. The GRUB menu will now present you with both: the previous deployment major version entry (e.g.: *"Fedora 30.YYYYMMDD.n"*) and the new deployment major version entry (e.g.: *"Fedora 31.YYYYMMDD.n"*).
+. When you have completed rebasing, reboot the system.
+The GRUB menu will now present you with both: the previous deployment major version entry (e.g.: *"Fedora 30.YYYYMMDD.n"*) and the new deployment major version entry (e.g.: *"Fedora 31.YYYYMMDD.n"*).
 +
 NOTE: At the moment it is not possible to name (pinned) deployments and their associated GRUB menu entries.

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,20 +1,16 @@
 [[getting-started]]
 = Getting Started
 
-{variant-name} is designed to be easy and straightforward to use, and specialist
-knowledge should generally not be required. However, {variant-name} is built
-differently from other operating systems, and there are therefore some things
-that it is useful to know.
+{variant-name} is designed to be easy and straightforward to use, and specialist knowledge should generally not be required.
+However, {variant-name} is built differently from other operating systems, and there are therefore some things that it is useful to know.
 
-{variant-name} has different options for installing software, compared with a
-standard Fedora Workstation (or other package-based Linux distributions). These
-include:
+{variant-name} has different options for installing software, compared with a standard Fedora Workstation (or other package-based Linux distributions).
+These include:
 
 * Flatpak apps: this is the primary way that (GUI) apps get installed on {variant-name}.
 * Toolbox: Used primarily for CLI apps; development, debugging tools etc.
-* Package layering: The rpm-ostree tool used for host updates is a full hybrid
-  image/package system.  By default the system operates in pure image mode,
-  but package layering is useful for things like libvirt, drivers, etc.
+* Package layering: The rpm-ostree tool used for host updates is a full hybrid image/package system.
+  By default the system operates in pure image mode, but package layering is useful for things like libvirt, drivers, etc.
 
 For information on <<flatpak>> and <<package-layering,package layering>>, see below.
 
@@ -23,72 +19,58 @@ See the dedicated xref:toolbox.adoc[toolbox] page to get started with it.
 [[flatpak]]
 == Flatpak
 
-Flatpak is the primary way that apps can be installed on {variant-name}. (For
-information, see http://flatpak.org[flatpak.org].) Flatpak works out of the box
-in Fedora {variant-name}, and Fedora provides a small (but growing) collection of
-apps that can be installed.
+Flatpak is the primary way that apps can be installed on {variant-name} (for more information, see http://flatpak.org[flatpak.org]).
+Flatpak works out of the box in Fedora {variant-name}, and Fedora provides a small (but growing) collection of apps that can be installed.
 
-The other main source of Flatpak apps is https://flathub.org/home[Flathub],
-which provides a large repository of Flatpak apps that can be installed.
+The other main source of Flatpak apps is https://flathub.org/home[Flathub], which provides a large repository of Flatpak apps that can be installed.
 
 [[flathub-setup]]
 == Setting up Flathub
 
-To setup Flathub on Fedora {variant-name}, open the
-https://flatpak.org/setup/Fedora/[Flathub setup page for Fedora] and click the
-“Flathub repository file” button to download the Flathub configuration.
+To setup Flathub on Fedora {variant-name}, open the https://flatpak.org/setup/Fedora/[Flathub setup page for Fedora] and click the “Flathub repository file” button to download the Flathub configuration.
 
 image::sfg_flathub_fedora.png[title="Fedora quick setup page"]
 
-A popup window will show a download option for the file. The “Open with” option
-should show “Software Install (default)”. Click on the “OK” button to start the 
-download.
+A popup window will show a download option for the file.
+The “Open with” option should show “Software Install (default)”.
+Click on the “OK” button to start the download.
 
 image::sfg_flathub_download.png[title="Flathub download options"]
 
-After the download is complete, a new window will open showing the Flathub
-repository. This window also shows the source location of the repository to be
-installed, under the details heading (1). To start the installation of the
-Flathub repository, click on the “Install” button (2).
+After the download is complete, a new window will open showing the Flathub repository.
+This window also shows the source location of the repository to be installed, under the details heading (1).
+To start the installation of the Flathub repository, click on the “Install” button (2).
 
 image::sfg_flathub_install.png[title="Flathub install window"]
 
-After the repository installation process is complete, the window will be
-updated to show a “Remove" button in place of the “Install” button.
+After the repository installation process is complete, the window will be updated to show a “Remove" button in place of the “Install” button.
 
 === Installing Flatpak apps from Flathub
 
-Once the Flathub repository has been setup, it can be used to install Flatpak
-apps. This can be done directly from the Software app, or apps can be browsed
-on the https://flathub.org/home[Flathub website].
+Once the Flathub repository has been setup, it can be used to install Flatpak apps.
+This can be done directly from the Software app, or apps can be browsed on the https://flathub.org/home[Flathub website].
 
-If you choose to install apps from the Flathub website, clicking "Install" will
-download a file which will be opened by the Software app, which can then be
-used to install the app. For example, to install https://www.libreoffice.org/[LibreOffice], you first
-search for and open the LibreOffice page, and then press the “Install” button
-(2).
+If you choose to install apps from the Flathub website, clicking "Install" will download a file which will be opened by the Software app, which can then be used to install the app.
+For example, to install https://www.libreoffice.org/[LibreOffice], you first search for and open the LibreOffice page, and then press the “Install” button (2).
 
-After clicking the “Install” button, a download information window will be
-shown. Verify the correct Flatpak has been downloaded and then click on the
-“OK” button to begin installing the LibreOffice application.
+After clicking the “Install” button, a download information window will be shown.
+Verify the correct Flatpak has been downloaded and then click on the “OK” button to begin installing the LibreOffice application.
 
 image::sfg_libreoffice_install.png[title="LibreOffice Flatpak download"]
 
-Once the Flatpak is downloaded, the Software application will open a new
-window with an “Install” button (2). Click this button to begin installation.
+Once the Flatpak is downloaded, the Software application will open a new window with an “Install” button (2).
+Click this button to begin installation.
 
 === Flatpak command line
 
-In addition to using the Software app to install Flatpak apps, it is also
-possible to use the `flatpak` command line interface. See the
-http://docs.flatpak.org/en/latest/using-flatpak.html[Flatpak documentation] for
-how to do this.
+In addition to using the Software app to install Flatpak apps, it is also possible to use the `flatpak` command line interface.
+See the http://docs.flatpak.org/en/latest/using-flatpak.html[Flatpak documentation] for how to do this.
 
 [[package-layering]]
 == Package layering
 
-Package layering works by modifying your {variant-name} installation. As the name
-implies, it works by extending the packages from which {variant-name} is composed.
+Package layering works by modifying your {variant-name} installation.
+As the name implies, it works by extending the packages from which {variant-name} is composed.
 
 Good examples of packages to be layered would be:
 
@@ -96,21 +78,15 @@ Good examples of packages to be layered would be:
 * `sway`: A Wayland tiling compositor
 * `libvirt`: The libvirt daemon
 
-Most (but not all) RPM packages provided by Fedora can be installed on
-{variant-name} using this method.
+Most (but not all) RPM packages provided by Fedora can be installed on {variant-name} using this method.
 
-Currently, using package layering creates a new "deployment", or bootable
-filesystem root.  It does not affect your current root.  This preserves
-rollback and the transactional model, but means that the system must be
-rebooted after a package has been layered. If you don't want to reboot your
-system for switching to the new deployment, you can use an experimental
-`rpm-ostree ex apply-live` command to update the filesystem to see changes from
-new deployment, but it's generally expected that you use package layering
-sparingly, and use `flatpak` and `dnf install` inside a `toolbox` etc.
+Currently, using package layering creates a new "deployment", or bootable filesystem root.
+It does not affect your current root.
+This preserves rollback and the transactional model, but means that the system must be rebooted after a package has been layered.
+If you don't want to reboot your system for switching to the new deployment, you can use an experimental `rpm-ostree ex apply-live` command to update the filesystem to see changes from new deployment, but it's generally expected that you use package layering sparingly, and use `flatpak` and `dnf install` inside a `toolbox` etc.
 
-Package layering is generally done from the command line. However, the Software
-application does rely on it for installing a small number of apps that are
-currently difficult to install as Flatpaks.
+Package layering is generally done from the command line.
+However, the Software application does rely on it for installing a small number of apps that are currently difficult to install as Flatpaks.
 
 === Installing packages
 
@@ -118,32 +94,25 @@ Packages can be installed on {variant-name} using:
 
  $ rpm-ostree install <package name>
 
-This will download the package and any required dependencies, and recompose
-your {variant-name} image with them. `rpm-ostree` uses standard Fedora package
-names, which can be searched using DNF (this is not available on a {variant-name}
-host, but can be used in a xref:toolbox.adoc[toolbox]).
+This will download the package and any required dependencies, and recompose your {variant-name} image with them.
+`rpm-ostree` uses standard Fedora package names, which can be searched using DNF (this is not available on a {variant-name} host, but can be used in a xref:toolbox.adoc[toolbox]).
 
-Once a package has been installed in this manner, it will be kept up-to-date as
-new versions are released and as the base operating system is updated.
+Once a package has been installed in this manner, it will be kept up-to-date as new versions are released and as the base operating system is updated.
 
 === Replacing packages
 
-In some scenarios, you may want to test out a new version of `podman` or
-`kernel` or other packages that live on the host.  The `rpm-ostree override`
-command can be used to replace a package with a different version. You can
-download the package locally and run:
+In some scenarios, you may want to test out a new version of `podman` or `kernel` or other packages that live on the host.
+The `rpm-ostree override` command can be used to replace a package with a different version.
+You can download the package locally and run:
 
  $ rpm-ostree override replace <path to package>
 
-Or you can override packages without downloading using links from koji or
-bodhi. For example:
+Or you can override packages without downloading using links from koji or bodhi.
+For example:
 
  $ rpm-ostree override replace https://kojipkgs.fedoraproject.org//packages/podman/3.1.2/1.fc34/x86_64/podman-3.1.2-1.fc34.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/podman/3.1.2/1.fc34/x86_64/podman-plugins-3.1.2-1.fc34.x86_64.rpm
 
-You may also use `override remove` to effectively "hide" packages; they will
-still exist in the underlying base layer, but will not appear in the booted
-root.
+You may also use `override remove` to effectively "hide" packages; they will still exist in the underlying base layer, but will not appear in the booted root.
 
-Removing and replacing packages using package layering is not generally
-recommended. For more information, see the
-https://coreos.github.io/rpm-ostree/administrator-handbook/[rpm-ostree documentation].
+Removing and replacing packages using package layering is not generally recommended.
+For more information, see the https://coreos.github.io/rpm-ostree/administrator-handbook/[rpm-ostree documentation].

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -4,47 +4,37 @@ Welcome to the Fedora {variant-name} user guide!
 
 image::silverblue-logo.svg[{variant-name} logo]
 
-_Fedora {variant-name}_ is an immutable desktop operating system. It aims to be
-extremely stable and reliable. It also aims to be an excellent platform for
-developers and for those using container-focused workflows.
+_Fedora {variant-name}_ is an immutable desktop operating system.
+It aims to be extremely stable and reliable.
+It also aims to be an excellent platform for developers and for those using container-focused workflows.
 
 [[introduction]]
 == Introduction to {variant-name}
 
-{variant-name} is a variant of Fedora Workstation. It looks, feels and behaves like
-a regular desktop operating system, and the experience is similar to what you
-find with using a standard Fedora Workstation.
+{variant-name} is a variant of Fedora Workstation.
+It looks, feels and behaves like a regular desktop operating system, and the experience is similar to what you find with using a standard Fedora Workstation.
 
-However, unlike other operating systems, {variant-name} is immutable. This means
-that every installation is identical to every other installation of the same
-version. The operating system that is on disk is exactly the same from one
-machine to the next, and it never changes as it is used.
+However, unlike other operating systems, {variant-name} is immutable.
+This means that every installation is identical to every other installation of the same version.
+The operating system that is on disk is exactly the same from one machine to the next, and it never changes as it is used.
 
-{variant-name}'s immutable design is intended to make it more stable, less prone to
-bugs, and easier to test and develop. Finally, {variant-name}'s immutable design
-also makes it an excellent platform for containerized applications as well as
-container-based software development. In each case, applications (apps) and
-containers are kept separate from the host system, improving stability and
-reliability.
+{variant-name}'s immutable design is intended to make it more stable, less prone to bugs, and easier to test and develop.
+Finally, {variant-name}'s immutable design also makes it an excellent platform for containerized applications as well as container-based software development.
+In each case, applications (apps) and containers are kept separate from the host system, improving stability and reliability.
 
-{variant-name}'s core technologies have some other helpful features. OS updates are
-fast and there's no waiting around for them to install: just reboot as normal
-to start using the next version. With {variant-name}, it is also possible to roll
-back to the previous version of the operating system, if something goes wrong.
+{variant-name}'s core technologies have some other helpful features.
+OS updates are fast and there's no waiting around for them to install: just reboot as normal to start using the next version.
+With {variant-name}, it is also possible to roll back to the previous version of the operating system, if something goes wrong.
 
 [[this-guide]]
 == About this guide
 
-In most cases, {variant-name} behaves like a standard Fedora Workstation
-installation, and the https://docs.fedoraproject.org/[standard Fedora
-documentation] can be used. This guide covers those areas where {variant-name}
-differs from a standard Fedora Workstation, including:
+In most cases, {variant-name} behaves like a standard Fedora Workstation installation, and the https://docs.fedoraproject.org/[standard Fedora documentation] can be used.
+This guide covers those areas where {variant-name} differs from a standard Fedora Workstation, including:
 
 * link:installation[OS installation]
 * link:getting-started[Installing apps and software]
 * link:updates-upgrades-rollbacks[OS upgrades and rollbacks]
 
-The primary audience for these docs are new users, who aren't expected to have
-specialist knowledge or technical knowledge about {variant-name}'s internals.
-However, some background link:technical-information[technical information] is
-provided, for those who are interested and want to learn more.
+The primary audience for these docs are new users, who aren't expected to have specialist knowledge or technical knowledge about {variant-name}'s internals.
+However, some background link:technical-information[technical information] is provided, for those who are interested and want to learn more.

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -1,58 +1,43 @@
 = Installing {variant-name}
 
-Fedora {variant-name} can be installed in the same way as Fedora Workstation, and
-the official Fedora installation guide can be followed for your Fedora version.
-See the https://docs.fedoraproject.org/en-US/docs/[Fedora documentation site]
-for more details.
+Fedora {variant-name} can be installed in the same way as Fedora Workstation, and the official Fedora installation guide can be followed for your Fedora version.
+See the https://docs.fedoraproject.org/en-US/docs/[Fedora documentation site] for more details.
 
 [[before-you-begin]]
 == Before you begin
 
-As with installing any new operating system, it is important to back up any
-data that you want to save before starting, and have a clear understanding of
-the consequences of what you are doing.
+As with installing any new operating system, it is important to back up any data that you want to save before starting, and have a clear understanding of the consequences of what you are doing.
 
-{variant-name} is intended to provide the full range of capabilities that you would
-expect from an installation of Fedora Workstation. However, there are some
-differences in terms of which applications can be installed, and how the
-operating system environment works.
+{variant-name} is intended to provide the full range of capabilities that you would expect from an installation of Fedora Workstation.
+However, there are some differences in terms of which applications can be installed, and how the operating system environment works.
 
-It is therefore recommended that you read this user guide before deciding to
-install {variant-name}. It is also recommended that you determine whether
-{variant-name} meets the specific needs or requirements that you might have. If you
-are uncertain about this, {variant-name} can also be tested in a virtual machine
-prior to installation or booted from a flash drive using Fedora Media Writer.
+It is therefore recommended that you read this user guide before deciding to install {variant-name}.
+It is also recommended that you determine whether {variant-name} meets the specific needs or requirements that you might have.
+If you are uncertain about this, {variant-name} can also be tested in a virtual machine prior to installation or booted from a flash drive using Fedora Media Writer.
 
 [[known-limitations]]
 == Known limitations
 
-*{variant-name} does not provide a fully functional experience for dual booting or
-manual partitioning.*
+*{variant-name} does not provide a fully functional experience for dual booting or manual partitioning.*
 
-It is possible to make {variant-name} work for both dual boot and manual
-partitioning, and some guidance is provided on manual partitioning below.
-However, there are hazards involved in both cases, and you should only attempt
-to use these features if you have done the necessary research, and are
-confident that you can overcome any issues that you might encounter.
+It is possible to make {variant-name} work for both dual boot and manual partitioning, and some guidance is provided on manual partitioning below.
+However, there are hazards involved in both cases, and you should only attempt to use these features if you have done the necessary research, and are confident that you can overcome any issues that you might encounter.
 
 [[getting-silverblue]]
 == Getting {variant-name}
 
-If you are using Fedora Media Writer, {variant-name} should be listed as a download
-option. However, if it isn't, or if you want to download it manually, an
-install image can be downloaded from
-{website}[the main {variant-name} website].
+If you are using Fedora Media Writer, {variant-name} should be listed as a download option.
+However, if it isn't, or if you want to download it manually, an install image can be downloaded from {website}[the main {variant-name} website].
 
-Once you have got your copy of {variant-name}, it can be installed in the usual
-manner. We hope that you love it!
+Once you have got your copy of {variant-name}, it can be installed in the usual manner.
+We hope that you love it!
 
 [[manual-partition]]
 == Manual Partitioning
 
-As described above, there are known issues with manual partitioning on
-{variant-name}, and it should be used with caution. The following notes are
-intended as hints for those attempting it, and should not be treated as
-recommended practice. Automatic partitioning is recommended.
+As described above, there are known issues with manual partitioning on {variant-name}, and it should be used with caution.
+The following notes are intended as hints for those attempting it, and should not be treated as recommended practice.
+Automatic partitioning is recommended.
 
 With {variant-name}, only certain mounts can be manually specified as partitions.
 These include:
@@ -65,14 +50,10 @@ These include:
 ** `/var/containers`
 * The root filesystem: `/`
 
-The Fedora installer is not aware of these restrictions and will accept custom
-partitions without error, even if they are incompatible with {variant-name}.
+The Fedora installer is not aware of these restrictions and will accept custom partitions without error, even if they are incompatible with {variant-name}.
 
 image::faw-manual-partition-complete.png[title="Partitioning Complete"]
 
-The above screenshot shows a typical configuration with manual partitioning,
-with partitions for `/boot`, `/`, `swap` and `/var/home`.
+The above screenshot shows a typical configuration with manual partitioning, with partitions for `/boot`, `/`, `swap` and `/var/home`.
 
-Manual partitioning on {variant-name} can be done with `Btrfs`,
-https://en.wikipedia.org/wiki/Logical_Volume_Manager_%28Linux%29[LVM], as well
-as standard partitions or an `xfs` filesystem.
+Manual partitioning on {variant-name} can be done with `Btrfs`, https://en.wikipedia.org/wiki/Logical_Volume_Manager_%28Linux%29[LVM], as well as standard partitions or an `xfs` filesystem.

--- a/modules/ROOT/pages/reading-and-resources.adoc
+++ b/modules/ROOT/pages/reading-and-resources.adoc
@@ -6,21 +6,13 @@ This page is a list of further reading and resources for {variant-name}.
 
 * https://buildah.io/[Buildah] - build OCI container images
 * http://flatpak.org[Flatpak] - next-generation desktop app framework
-* https://ostreedev.github.io/ostree/[ostree] - OS image composition and
-  updates
+* https://ostreedev.github.io/ostree/[ostree] - OS image composition and updates
 * https://podman.io/[podman] - daemonless container engine
-* https://coreos.github.io/rpm-ostree/[rpm-ostree] - hybrid image/package
-  system
+* https://coreos.github.io/rpm-ostree/[rpm-ostree] - hybrid image/package system
 
 == Documents
 
-* link:{attachmentsdir}/team-silverblue-origins.pdf[Team Silverblue - The
-  Origins] - PDF that explains the motivations, goals, and history behind
-  Silverblue
-* link:{attachmentsdir}/flatpak-print-cheatsheet.pdf[Flatpak Cheat Sheet] -
-  PDF with common flatpak commands
-* link:{attachmentsdir}/silverblue-cheatsheet.pdf[rpm-ostree Cheat Sheet] - PDF
-  with common rpm-ostree commands
-* link:{attachmentsdir}/container-commandos.pdf[Container commandos] -  a
-  playful introduction to tools such as podman, cri-o and buildah by Máirín Duffy
-  and Dan Walsh. Print it out, and learn as you color!
+* link:{attachmentsdir}/team-silverblue-origins.pdf[Team Silverblue - The Origins] - PDF that explains the motivations, goals, and history behind Silverblue
+* link:{attachmentsdir}/flatpak-print-cheatsheet.pdf[Flatpak Cheat Sheet] - PDF with common flatpak commands
+* link:{attachmentsdir}/silverblue-cheatsheet.pdf[rpm-ostree Cheat Sheet] - PDF with common rpm-ostree commands
+* link:{attachmentsdir}/container-commandos.pdf[Container commandos] -  a playful introduction to tools such as podman, cri-o and buildah by Máirín Duffy and Dan Walsh. Print it out, and learn as you color!

--- a/modules/ROOT/pages/technical-information.adoc
+++ b/modules/ROOT/pages/technical-information.adoc
@@ -1,45 +1,37 @@
 [technical-information]
 = Technical Information
 
-This page provides some background technical information on {variant-name},
-including information on the core technologies used to build it, as well as the
-filesystem layout.
+This page provides some background technical information on {variant-name}, including information on the core technologies used to build it, as well as the filesystem layout.
 
-Users should not need to know this information. It is provided here for those
-who are interested in the technical details or those who want to use {variant-name}
-in a non-standard manner.
+Users should not need to know this information.
+It is provided here for those who are interested in the technical details or those who want to use {variant-name} in a non-standard manner.
 
 [[ostree-rpm-ostree]]
 == ostree and rpm-ostree
 
-https://ostreedev.github.io/ostree/[ostree] is the core technology that is used
-to compose, deploy and update {variant-name}. ostree operates in a similar manner
-to a version control system, but it operates on entire filesystem trees. It is
-often described as “Git for operating system binaries”.
+https://ostreedev.github.io/ostree/[ostree] is the core technology that is used to compose, deploy and update {variant-name}.
+ostree operates in a similar manner to a version control system, but it operates on entire filesystem trees.
+It is often described as “Git for operating system binaries”.
 
-For {variant-name} installs, ostree is responsible for deploying and updating the
-OS image (including everything below `/` that is not symlinked into `/var`). It
-also updates `grub.cfg` entries to point to the current image.
+For {variant-name} installs, ostree is responsible for deploying and updating the OS image (including everything below `/` that is not symlinked into `/var`).
+It also updates `grub.cfg` entries to point to the current image.
 
-https://coreos.github.io/rpm-ostree/[rpm-ostree] builds on top of ostree, and
-makes it possible to install RPMs as a “layer” on top of an ostree image. This
-makes it possible to install RPMs on {variant-name}.
+https://coreos.github.io/rpm-ostree/[rpm-ostree] builds on top of ostree, and makes it possible to install RPMs as a “layer” on top of an ostree image.
+This makes it possible to install RPMs on {variant-name}.
 
-When a package is installed with `rpm-ostree`, a new OS image is composed by
-adding the RPM payload to the existing OS image, and creating a new, combined
-image. To see the newly installed RPMs, the system needs to be rebooted with
-the new image. rpm-ostree also takes care of recreating the layered image
-whenever you update the base OS image.
+When a package is installed with `rpm-ostree`, a new OS image is composed by adding the RPM payload to the existing OS image, and creating a new, combined image.
+To see the newly installed RPMs, the system needs to be rebooted with the new image.
+rpm-ostree also takes care of recreating the layered image whenever you update the base OS image.
 
 [[filesystem-layout]]
 == {variant-name} filesystem layout
 
-On {variant-name}, the root filesystem is immutable. This means that `/`, `/usr`
-and everything below it is read-only.
+On {variant-name}, the root filesystem is immutable.
+This means that `/`, `/usr` and everything below it is read-only.
 
-`/var` is where all of {variant-name}'s runtime state is stored. Symlinks are used
-to make traditional state-carrying directories available in their expected
-locations. This includes:
+`/var` is where all of {variant-name}'s runtime state is stored.
+Symlinks are used to make traditional state-carrying directories available in their expected locations.
+This includes:
 
 * `/home` → `/var/home`
 * `/opt` → `/var/opt`
@@ -51,6 +43,4 @@ locations. This includes:
 
 This means that separate home partitions should be mounted on `/var/home`.
 
-For a more detailed explanation of {variant-name}'s filesystem layout, refer to the
-excellent
-https://ostreedev.github.io/ostree/adapting-existing/[libostree documentation].
+For a more detailed explanation of {variant-name}'s filesystem layout, refer to the excellent https://ostreedev.github.io/ostree/adapting-existing/[libostree documentation].

--- a/modules/ROOT/pages/tips-and-tricks.adoc
+++ b/modules/ROOT/pages/tips-and-tricks.adoc
@@ -4,25 +4,20 @@
 
 === Finding out if you are currently in a Toolbx container
 
-If you frequently make use of Toolbx to perform various tasks and use multiple
-Toolbx containers it can be hard to keep track of whether you are currently
-executing commands on the host or in a Toolbx container. Furthermore, there is
-currently no command to tell you in which Toolbx container you are working.
+If you frequently make use of Toolbx to perform various tasks and use multiple Toolbx containers it can be hard to keep track of whether you are currently executing commands on the host or in a Toolbx container.
+Furthermore, there is currently no command to tell you in which Toolbx container you are working.
 
-To alleviate this, you can add the following shell alias at the end of your
-`~/.bashrc`:
+To alleviate this, you can add the following shell alias at the end of your `~/.bashrc`:
 
   alias istoolbx='[ -f "/run/.toolboxenv" ] && grep -oP "(?<=name=\")[^\";]+" /run/.containerenv'
 
 When you open a new shell, you now have access to the new command `istoolbx`.
-This will behave as follows
+This will behave as follows:
 
 * When run from the host, returns an exit code of 1
-* When run from a Toolbx container, returns an exit code of 0 and prints the
-  current Toolbx containers name to the console
-  
-If a more automated solution is your preference the following added to your `~/.bashrc` will change your bash prompt to
-include "[toolbox <name>]":
+* When run from a Toolbx container, returns an exit code of 0 and prints the current Toolbx containers name to the console
+
+If a more automated solution is your preference the following added to your `~/.bashrc` will change your bash prompt to include "[toolbox <name>]":
 
 ```
 function is_toolbox() {
@@ -34,8 +29,7 @@ function is_toolbox() {
 }
 ```
 
-Now you can include `is_toolbox` in your `PS1` variable and not need to execute any extra commands
-in order to know whether or not your are in a toolbox or host shell.
+Now you can include `is_toolbox` in your `PS1` variable and not need to execute any extra commands in order to know whether or not your are in a toolbox or host shell.
 
 Example:
 ```
@@ -43,53 +37,43 @@ export PS1="\[\e[31m\]\`is_toolbox\`\]\e[m\]\[\e[32m\]\\$ \[\e[m\]\[\e[37m\]❱\
 ```
 
 This results in a prompt which appears as such when not in a toolbox: `$ ❱`
-However, when running in a toolbox named "default" looks like: `[toolbox default]$ ❱`
 
+However, when running in a toolbox named "default" looks like: `[toolbox default]$ ❱`
 
 === Running applications from inside Toolbx on the host
 
-This can be necessary if you want to interact with tools available from the
-host, for example `podman`, `nmcli` or `rpm-ostree` without leaving the Toolbx
-container in between. You can use `flatpak-spawn`, included in the base
-installation for this:
+This can be necessary if you want to interact with tools available from the host, for example `podman`, `nmcli` or `rpm-ostree` without leaving the Toolbx container in between.
+You can use `flatpak-spawn`, included in the base installation for this:
 
   $ flatpak-spawn --host podman --help
 
-If the application you want to call requires `sudo` access, the `-S` option must
-be supplied to `sudo` like below:
+If the application you want to call requires `sudo` access, the `-S` option must be supplied to `sudo` like below:
 
   $ flatpak-spawn --host sudo -S rpm-ostree status
 
-If you find yourself using commands like these frequently to access e.g. the
-flatpak command from inside the Toolbx container, you can create yourself a
-short custom wrapper script (*inside the Toolbx container*). To do this, perform
-the following steps:
+If you find yourself using commands like these frequently to access e.g. the flatpak command from inside the Toolbx container, you can create yourself a short custom wrapper script (*inside the Toolbx container*).
+To do this, perform the following steps:
 
-1. Define the `istoolbx` alias (for convenience) by executing the command
-   mentioned above in your terminal
+1. Define the `istoolbx` alias (for convenience) by executing the command mentioned above in your terminal
 
-2. Make sure you are in a Toolbx container. If the following command doesn't
-   produce any output, you are likely still working on the host!
+2. Make sure you are in a Toolbx container.
+   If the following command doesn't produce any output, you are likely still working on the host!
 
      [toolbx]$ istoolbx
      <Toolbx container name here>
 
-3. Once you have made sure you're in a Toolbx container, execute the following
-   command:
+3. Once you have made sure you're in a Toolbx container, execute the following command:
 
     [toolbx]$ echo -e '#!/bin/sh\nexec /usr/bin/flatpak-spawn --host flatpak "$@"' | sudo tee /usr/local/bin/flatpak 1>/dev/null && sudo chmod +x /usr/local/bin/flatpak
 
-You now have a `flatpak` command available that allows you to interact with
-`flatpak` as if you were running the command on the host.
-
+You now have a `flatpak` command available that allows you to interact with `flatpak` as if you were running the command on the host.
 
 == Working with `ostree`/`rpm-ostree`
 
 === Tracking changes to the base OS
 
-Some directories in `ostree`-based operating systems are writable by the user,
-like `/etc`. You can get a quick overview of the files changed under `/etc`
-using the following command:
+Some directories in `ostree`-based operating systems are writable by the user, like `/etc`.
+You can get a quick overview of the files changed under `/etc` using the following command:
 
   $ sudo ostree admin config-diff
 
@@ -97,18 +81,14 @@ To get a more elaborate diff, you can use something like this:
 
   $ sudo diff -yrW200 --suppress-common-lines --color=always /usr/etc /etc 2>/dev/null
 
-NOTE: This works because ostree keeps an unmodified copy of the `/etc` directory
-      under `/usr/etc`. All of your changes go to `/etc` directly.
-
-
+NOTE: This works because ostree keeps an unmodified copy of the `/etc` directory under `/usr/etc`.
+      All of your changes go to `/etc` directly.
 
 == Working with Flatpak applications
 
 === Directly accessing Flatpak applications from the CLI
 
-The most noticable change when using Flatpak applications instead of
-conventional installations is that the applications cannot be directly called
-from the CLI any more, like so:
+The most noticable change when using Flatpak applications instead of conventional installations is that the applications cannot be directly called from the CLI any more, like so:
 
   $ evince
   bash: command not found: evince
@@ -117,19 +97,15 @@ Instead, one can call them like this:
 
   $ flatpak run org.gnome.Evince
 
-In addition, most Flatpak applications export their internal binaries under an
-installation-dependent location:
+In addition, most Flatpak applications export their internal binaries under an installation-dependent location:
 
-* For Flatpak applications installed from `system` remotes, these can be found
-  under `/var/lib/flatpak/exports/bin/`
-* For Flatpak applications installed from `user` remotes, these can be found
-  under `$HOME/.local/share/flatpak/exports/bin/`
+* For Flatpak applications installed from `system` remotes, these can be found under `/var/lib/flatpak/exports/bin/`
+* For Flatpak applications installed from `user` remotes, these can be found under `$HOME/.local/share/flatpak/exports/bin/`
 
 [NOTE]
 ====
-If you're unsure to which installation a Flatpak application belongs, you can
-use this command to print it out:
-        
+If you're unsure to which installation a Flatpak application belongs, you can use this command to print it out:
+
   $ flatpak list --app --columns=name,installation
 ====
 
@@ -142,4 +118,3 @@ or setup shell `alias`es as needed to make them available to the CLI like so:
   $ alias evince="flatpak run org.gnome.Evince"
     # or alias evince="org.gnome.Evince"
   $ evince
-

--- a/modules/ROOT/pages/toolbox.adoc
+++ b/modules/ROOT/pages/toolbox.adoc
@@ -1,76 +1,57 @@
 [[toolbox]]
 = Toolbox
 
-As an immutable host, {variant-name} is an excellent platform for container-based
-development and, for working with containers, https://buildah.io/[buildah] and
-https://podman.io/[podman] are recommended.
+As an immutable host, {variant-name} is an excellent platform for container-based development and, for working with containers, https://buildah.io/[buildah] and https://podman.io/[podman] are recommended.
 
-{variant-name} also comes with the https://github.com/containers/toolbox[toolbox]
-utility, which uses containers to provide an environment where development
-tools and libraries can be installed and used.
+{variant-name} also comes with the https://github.com/containers/toolbox[toolbox] utility, which uses containers to provide an environment where development tools and libraries can be installed and used.
 
 [[toolbox-why-use]]
 == Why use toolbox?
 
-Toolbox makes it easy to use a containerized environment for everyday software
-development and debugging. On immutable operating systems, like
-{website}[Fedora {variant-name}], it provides a
-familiar package-based environment in which tools and libraries can be
-installed and used. However, toolbox can also be used on package-based systems.
+Toolbox makes it easy to use a containerized environment for everyday software development and debugging.
+On immutable operating systems, like {website}[Fedora {variant-name}], it provides a familiar package-based environment in which tools and libraries can be installed and used.
+However, toolbox can also be used on package-based systems.
 
-Using Toolbox for running your workflows in a containerized manner brings you
-several advantages:
+Using Toolbox for running your workflows in a containerized manner brings you several advantages:
 
-* It keeps the host OS clean and stable, and helps to avoid the clutter that
-  can happen after installing lots of development tools and packages.
-* You get access to different versions of supported distributions independent
-  of the version you are running.
-* Containers are a good way to isolate and organise the dependencies needed for
-  different projects.
-* Containers are a safe space to experiment: if things go wrong, it's easy to
-  throw a toolbox away and start again.
+* It keeps the host OS clean and stable, and helps to avoid the clutter that can happen after installing lots of development tools and packages.
+* You get access to different versions of supported distributions independent of the version you are running.
+* Containers are a good way to isolate and organise the dependencies needed for different projects.
+* Containers are a safe space to experiment: if things go wrong, it's easy to throw a toolbox away and start again.
 
 [[toolbox-how-it-works]]
 == How it works
 
-Toolbox takes the work out of using containers, by providing a small number of
-simple commands to create, enter, list and remove containers. It also
-integrates toolbox containers into your regular working environment, to make it
-easy for you to use them as an everyday development space.
+Toolbox takes the work out of using containers, by providing a small number of simple commands to create, enter, list and remove containers.
+It also integrates toolbox containers into your regular working environment, to make it easy for you to use them as an everyday development space.
 
-Containers are created from images and those are usually a very stripped down
-version of distributions. In such images there are almost no tools and
-documentation available. The team behind Toolbox maintains a Fedora image where
-such tools and documentation are available, providing a good out of the
-box experience.
+Containers are created from images and those are usually a very stripped down version of distributions.
+In such images there are almost no tools and documentation available.
+The team behind Toolbox maintains a Fedora image where such tools and documentation are available, providing a good out of the box experience.
 
-Each toolbox container is an environment that you can enter from the command
-line. Inside each one, you will find:
+Each toolbox container is an environment that you can enter from the command line.
+Inside each one, you will find:
 
 * Your existing username and permissions
 * Access to your home directory and several other locations
 * Access to both system and session D-Bus, system journal and Kerberos
 * Common command lines tools, including a package manager (e.g., DNF on Fedora)
 
-In other words, toolbox containers look, feel and behave like a standard Linux
-command line environment. By connecting all this information, toolbox
-containers lose a certain amount of security gained by using the containers
-technology. Therefore, you should not treat toolbox containers as a sandbox
-where you can execute any script you would never run on any other system.
+In other words, toolbox containers look, feel and behave like a standard Linux command line environment.
+By connecting all this information, toolbox containers lose a certain amount of security gained by using the containers technology.
+Therefore, you should not treat toolbox containers as a sandbox where you can execute any script you would never run on any other system.
 
-In most cases, when a command is run inside a container, the program from
-inside the container is used. However, there are a few special cases where the
-program on the host is used instead (using `flatpak-spawn`). One example of
-this is the toolbox command itself; this makes it possible to use toolbox from
-inside toolbox containers.
+In most cases, when a command is run inside a container, the program from inside the container is used.
+However, there are a few special cases where the program on the host is used instead (using `flatpak-spawn`).
+One example of this is the toolbox command itself; this makes it possible to use toolbox from inside toolbox containers.
 
 [[toolbox-installation]]
 == Installation
 
 === Fedora {variant-name}
 
-Toolbox is preinstalled on Fedora {variant-name} 30 or newer. On older versions, it
-can be installed with the following command:
+Toolbox is preinstalled on Fedora {variant-name} 30 or newer.
+On older versions, it can be installed with the following command:
 
  $ rpm-ostree install toolbox
 
@@ -78,8 +59,7 @@ This will install toolbox as a layered RPM.
 
 === Fedora Workstation
 
-Toolbox can be installed on Fedora Workstation (or any package-based version of
-Fedora) with the following command:
+Toolbox can be installed on Fedora Workstation (or any package-based version of Fedora) with the following command:
 
  $ sudo dnf install toolbox
 
@@ -90,17 +70,15 @@ Once toolbox is installed, two simple commands are required to get started:
 
  $ toolbox create
 
-This will download an OCI image and create a toolbox container from it. Once
-this is complete, run:
+This will download an OCI image and create a toolbox container from it.
+Once this is complete, run:
 
  $ toolbox enter
 
-Once inside the toolbox, you can access common command line tools, and install
-new ones using a package manager (e.g., DNF on Fedora).
+Once inside the toolbox, you can access common command line tools, and install new ones using a package manager (e.g., DNF on Fedora).
 
-NOTE: When the prompt is inside a toolbox, it is prepended with a diamond: this
-indicates that the prompt is inside a toolbox container. The diamond symbol may
-not be present if you use a custom shell theme.
+NOTE: When the prompt is inside a toolbox, it is prepended with a diamond: this indicates that the prompt is inside a toolbox container.
+      The diamond symbol may not be present if you use a custom shell theme.
 
 [[toolbox-commands]]
 == Commands and usage
@@ -108,50 +86,43 @@ not be present if you use a custom shell theme.
 [[toolbox-create]]
 === toolbox create [options] <name>
 
-Creates a toolbox container. This will download an OCI image if one isn't
-available (this is required to create the container). By default an image
-matching the version of the host is used. If the host system does not have a
-matching image, a Fedora image is used instead.
+Creates a toolbox container.
+This will download an OCI image if one isn't available (this is required to create the container).
+By default an image matching the version of the host is used.
+If the host system does not have a matching image, a Fedora image is used instead.
 
-Used without options, `toolbox create` will automatically name the container it
-creates. To create additional toolboxes, use the `<name>` argument.
+Used without options, `toolbox create` will automatically name the container it creates.
+To create additional toolboxes, use the `<name>` argument.
 
-To use a specific version of the host system (e.g., Fedora 32 on Fedora 34),
-use the `--release <release> | -r <release>` option.
+To use a specific version of the host system (e.g., Fedora 32 on Fedora 34), use the `--release <release> | -r <release>` option.
 
-To use a different distribution to create a toolbox container (e.g., RHEL on
-Fedora), use the `--distro <distro> | -d <distro>` option.
+To use a different distribution to create a toolbox container (e.g., RHEL on Fedora), use the `--distro <distro> | -d <distro>` option.
 
 To use a different image, use the ``--image <name> | -i <name>`` option.
 
 [[toolbox-enter]]
 === toolbox enter [options] <name>
 
-Enters a toolbox for interactive use. Used without options, `toolbox enter`
-opens the default toolbox.
+Enters a toolbox for interactive use.
+Used without options, `toolbox enter` opens the default toolbox.
 
 To enter a toolbox with specific name, use the `name` argument.
 
-To enter a toolbox for a different distribution (e.g., Fedora on RHEL), use the
-`--distro <distro> |-d <distro>` option.
+To enter a toolbox for a different distribution (e.g., Fedora on RHEL), use the `--distro <distro> |-d <distro>` option.
 
-To enter a toolbox with specific version (e.g., RHEL 8.1 on RHEL 8.3), use the
-`--release <release> | -r <release>` option.
+To enter a toolbox with specific version (e.g., RHEL 8.1 on RHEL 8.3), use the `--release <release> | -r <release>` option.
 
 [[toolbox-run]]
 === toolbox run [options] <cmd> <arg ...>
 
-Runs a command in a toolbox without entering it. Used without options, `toolbox
-run` runs the command in the default toolbox.
+Runs a command in a toolbox without entering it.
+Used without options, `toolbox run` runs the command in the default toolbox.
 
-To run a command in a toolbox with specific name, use the `--container <name> |
--c <name>` option.
+To run a command in a toolbox with specific name, use the `--container <name> | -c <name>` option.
 
-To run a command in a toolbox for a different distribution (e.g., Fedora on
-RHEL), use the `--distro <distro> |-d <distro>` option.
+To run a command in a toolbox for a different distribution (e.g., Fedora on RHEL), use the `--distro <distro> |-d <distro>` option.
 
-To run a command in a toolbox with specific version (e.g., RHEL 8.1 on RHEL
-8.3), use the `--release <release> | -r <release>` option.
+To run a command in a toolbox with specific version (e.g., RHEL 8.1 on RHEL 8.3), use the `--release <release> | -r <release>` option.
 
 [[toolbox-list]]
 === toolbox list [options]
@@ -167,8 +138,7 @@ To only show images, use the `--images | -i` option.
 
 Removes one or more toolbox containers.
 
-The `--force | -f` option removes the marked containers even if they are
-running.
+The `--force | -f` option removes the marked containers even if they are running.
 
 The `--all | -a` option removes all toolbox containers.
 
@@ -177,8 +147,7 @@ The `--all | -a` option removes all toolbox containers.
 
 Removes one or more toolbox images.
 
-The `--force | -f` option removes the marked images and all containers that
-have been created using the marked images.
+The `--force | -f` option removes the marked images and all containers that have been created using the marked images.
 
 The `--all | -a` option removes all toolbox images.
 
@@ -190,8 +159,7 @@ Shows Toolbox's manual page.
 [[toolbox-exiting]]
 === Exiting a toolbox
 
-To return to the host environment, either run `exit` or quit the current shell
-(typically Ctrl+D).
+To return to the host environment, either run `exit` or quit the current shell (typically Ctrl+D).
 
 [[toolbox-under-the-hood]]
 == Under the hood
@@ -204,9 +172,6 @@ Toolbox uses the following technologies:
 [[toolbox-contact]]
 == Contact and issues
 
-To report issues, make suggestions, or contribute fixes, see
-https://github.com/containers/toolbox[toolbox's GitHub project].
+To report issues, make suggestions, or contribute fixes, see https://github.com/containers/toolbox[toolbox's GitHub project].
 
-To get in touch with toolbox users and developers, use
-https://discussion.fedoraproject.org/[Fedora's Discourse instance], or join the
-#silverblue IRC channel on https://libera.chat/[Libera].
+To get in touch with toolbox users and developers, use https://discussion.fedoraproject.org/[Fedora's Discourse instance], or join the #silverblue IRC channel on https://libera.chat/[Libera].

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -1,47 +1,35 @@
 = Troubleshooting
 
-{variant-name} is a radically new way of deploying and managing your
-desktop operating system, so you may occasionally run into problems
-while going through your day to day.  Below are some of the more
-common problems reported and any workarounds for those problems.
+{variant-name} is a radically new way of deploying and managing your desktop operating system, so you may occasionally run into problems while going through your day to day.
+Below are some of the more common problems reported and any workarounds for those problems.
 
 == "Forbidden base package replacements"
 
 https://github.com/projectatomic/rpm-ostree/issues/415[GitHub Issue]
 
-This can happen when a package that is being layered has a
-dependency on a package that is in the base OS.  In the
-problematic case, the layered package requires a newer version
-of the dependent package which is not available in the base OS.
+This can happen when a package that is being layered has a dependency on a package that is in the base OS.
+In the problematic case, the layered package requires a newer version of the dependent package which is not available in the base OS.
 
-In most cases, waiting for a newer OSTree compose will resolve
-this problem.  The dependent package will be updated in the compose
-and the package that was going to be layered will be successful.
+In most cases, waiting for a newer OSTree compose will resolve this problem.
+The dependent package will be updated in the compose and the package that was going to be layered will be successful.
 
-However, if you continue to encounter this problem with a newer
-compose, you can try to cleanup the metadata with `rpm-ostree cleanup -m`
-and then retrying the `rpm-ostree install`.
+However, if you continue to encounter this problem with a newer compose, you can try to cleanup the metadata with `rpm-ostree cleanup -m` and then retrying the `rpm-ostree install`.
 
-Alternatively, you can try rebasing to any `updates` ref,
-like `fedora/30/updates/x86_64` after the `cleanup` operation.
+Alternatively, you can try rebasing to any `updates` ref, like `fedora/30/updates/x86_64` after the `cleanup` operation.
 
 == Installing packages to `/opt` or `/usr/local`
 
 https://github.com/projectatomic/rpm-ostree/issues/233[GitHub Issue]
 
-Installing into `/opt` was commonly raised as a problem when users where
-trying to install Google Chrome.  A partial https://github.com/projectatomic/rpm-ostree/pull/1795[solution] has been implemented
-that allows users to layer Google Chrome, however it is not a complete
-solution for applications that write mutable data to `/opt`.
+Installing into `/opt` was commonly raised as a problem when users where trying to install Google Chrome.
+A partial https://github.com/projectatomic/rpm-ostree/pull/1795[solution] has been implemented that allows users to layer Google Chrome, however it is not a complete solution for applications that write mutable data to `/opt`.
 
 == Using Nvidia drivers
 
 https://github.com/projectatomic/rpm-ostree/issues/1091[GitHub Issue]
 
 Users have long wanted to use their Nvidia GPUs on their {variant-name} systems.
-Thankfully, recent changes to the `akmods` and `kmodtools` packages were
-made by https://twitter.com/gnomealex[Alex Larsson] to allow for normal
-installation of the Nvidia drivers.
+Thankfully, recent changes to the `akmods` and `kmodtools` packages were made by https://twitter.com/gnomealex[Alex Larsson] to allow for normal installation of the Nvidia drivers.
 
  # rpm-ostree install kmod-nvidia xorg-x11-drv-nvidia
  # rpm-ostree kargs --append=rd.driver.blacklist=nouveau --append=modprobe.blacklist=nouveau --append=nvidia-drm.modeset=1
@@ -50,11 +38,9 @@ You can read more about the work that Alex did on his https://blogs.gnome.org/al
 
 == SELinux problems
 
-As users work with {variant-name} day-to-day, it is possible that they have modified
-the default SELinux policy in an effort to workaround one or more problems related
-to SELinux. This is usually done when a user sees a SELinux denial in the journal.
-If this is the case and one wishes to revert back to the default SELinux policy,
-you can try these set of actions.
+As users work with {variant-name} day-to-day, it is possible that they have modified the default SELinux policy in an effort to workaround one or more problems related to SELinux.
+This is usually done when a user sees a SELinux denial in the journal.
+If this is the case and one wishes to revert back to the default SELinux policy, you can try these set of actions.
 
 . Check the state of the SELinux policy
 +
@@ -64,26 +50,23 @@ you can try these set of actions.
  M    selinux/targeted/policy/policy.31
  A    selinux/targeted/policy/policy.30
 +
-If anything is returned by this command, then your SELinux policy has been modified
-from the default.
+If anything is returned by this command, then your SELinux policy has been modified from the default.
 +
-.  Copy the default SELinux policy shipped in the OSTree compose
+. Copy the default SELinux policy shipped in the OSTree compose
 +
  $ sudo cp -al /etc/selinux{,.bak}
  $ sudo rsync -rlv /usr/etc/selinux/ /etc/selinux/
 +
-After doing this, the output from `ostree admin config-diff | grep policy` should
-no longer indicate the policy is modified.
+After doing this, the output from `ostree admin config-diff | grep policy` should no longer indicate the policy is modified.
 +
 If your policy still appears to be modified, you can try the following approach.
 +
-.  Remove the SELinux policy; copy in the default policy
+. Remove the SELinux policy; copy in the default policy
 +
  $ sudo rm -rf /etc/selinux
  $ sudo cp -aT /usr/etc/selinux /etc/selinux
 +
-After this, the `ostree admin config-diff | grep policy` command should return
-no modifications.
+After this, the `ostree admin config-diff | grep policy` command should return no modifications.
 
 == Unable to add user to group
 
@@ -91,12 +74,9 @@ https://github.com/projectatomic/rpm-ostree/issues/29[GitHub Issue]
 
 https://github.com/projectatomic/rpm-ostree/issues/49[GitHub Issue]
 
-Due to how `rpm-ostree` handles user + group entries, it may not be possible
-to use `usermod -a -G` to add a user to a group successfully.  Until the
-`rpm-ostree` moves to using `systemd sysusers`, users will have to
-populate the `/etc/group` file from the `/usr/lib/group` file before they
-can add themselves to the group.  For example, if you wanted to add a user
-to the `libvirt` group:
+Due to how `rpm-ostree` handles user + group entries, it may not be possible to use `usermod -a -G` to add a user to a group successfully.
+Until the `rpm-ostree` moves to using `systemd sysusers`, users will have to populate the `/etc/group` file from the `/usr/lib/group` file before they can add themselves to the group.
+For example, if you wanted to add a user to the `libvirt` group:
 
  # grep -E '^libvirt:' /usr/lib/group >> /etc/group
  # usermod -aG libvirt username
@@ -105,23 +85,18 @@ NOTE: You will need to log off and log back in to apply these changes.
 
 == `ostree fsck` reports file corruption
 
-It is possible to end up in a situation where one or more files on the disk
-have become corrupted or missing.  In this case, `ostree fsck` will report
-errors in certain commits.  The https://github.com/ostreedev/ostree/pull/345#issuecomment-262263824[workaround]
-in this case is to mark the entire OSTree commit as partially retrieved and then re-pull the commit.
+It is possible to end up in a situation where one or more files on the disk have become corrupted or missing.
+In this case, `ostree fsck` will report errors in certain commits.
+The https://github.com/ostreedev/ostree/pull/345#issuecomment-262263824[workaround] in this case is to mark the entire OSTree commit as partially retrieved and then re-pull the commit.
 
 == Read-only `/boot/efi` prevents any upgrades
 
 https://github.com/projectatomic/rpm-ostree/issues/1380[GitHub Issue]
 
-This issue is most commonly seen when users have installed {variant-name}
-on Apple hardware. The `/boot/efi` partition on Apple hardware is
-formatted as HFS+ and is not always resilient to power failures or
-other kinds of hard power events.
+This issue is most commonly seen when users have installed {variant-name} on Apple hardware.
+The `/boot/efi` partition on Apple hardware is formatted as HFS+ and is not always resilient to power failures or other kinds of hard power events.
 
-Since {variant-name} now includes the `hfsplus-tools` package in the base
-compose, it has become relatively easy for users to workaround this
-kind of error.
+Since {variant-name} now includes the `hfsplus-tools` package in the base compose, it has become relatively easy for users to workaround this kind of error.
 
  # umount /boot/efi
  # fsck.hfsplus /dev/sda1
@@ -133,30 +108,34 @@ See the linked issue for additional details.
 
 https://bugzilla.redhat.com/show_bug.cgi?id=1575957[Bugzilla Issue]
 
-Users have reported that they cannot install {variant-name} on an EFI based
-system where they previously had another OS installed. The error that
-is often observed looks like:
+Users have reported that they cannot install {variant-name} on an EFI based system where they previously had another OS installed.
+The error that is often observed looks like:
 
  ostree ['admin', '--sysroot=/mnt/sysimage', 'deploy', '--os=fedora-workstation', 'fedora-workstation:fedora/28/x86_64/workstation'] exited with code -6`
 
 A couple of possible workarounds exist:
 
-* During the install process, select "Custom Partitioning" and create an additional EFI partition. Assign the newly created EFI partition to `/boot/efi`. You will then be able to boot the previous OS(s) alongside Fedora {variant-name}. If this workaround is not successful follow the below step.
-* Reformat the EFI partition on the host during the install process. This can be done by selecting "Custom Partitioning" and checking the `Reformat` box when creating the `/boot/efi` partition.
+* During the install process, select "Custom Partitioning" and create an additional EFI partition.
+  Assign the newly created EFI partition to `/boot/efi`.
+  You will then be able to boot the previous OS(s) alongside Fedora {variant-name}.
+  If this workaround is not successful follow the below step.
+* Reformat the EFI partition on the host during the install process.
+  This can be done by selecting "Custom Partitioning" and checking the `Reformat` box when creating the `/boot/efi` partition.
 
-WARNING: Choosing to reformat `/boot/efi` will likely result in the inability
-to boot any other operating systems that were previously installed. Be sure that
-you have backed up any important data before using this workaround.
+WARNING: Choosing to reformat `/boot/efi` will likely result in the inability to boot any other operating systems that were previously installed.
+         Be sure that you have backed up any important data before using this workaround.
 
 == `toolbox: failed to list images with com.redhat.component=fedora-toolbox`
 
-IMPORTANT: As of `podman` version `1.4.0` this workaround is not necessary. Ensure `podman` is up to date by issuing `rpm-ostree upgrade` before attempting this workaround.
+IMPORTANT: As of `podman` version `1.4.0` this workaround is not necessary.
+           Ensure `podman` is up to date by issuing `rpm-ostree upgrade` before attempting this workaround.
 
 When issuing the `toolbox list` command, systems using `podman` versions newer than `1.2.0`, will generate the following error:
 
  toolbox: failed to list images with com.redhat.component=fedora-toolbox
 
-TIP: The following workaround might be useful for other `toolbox` errors caused by `podman` versions greater than `1.2.0`. See https://github.com/debarshiray/toolbox/issues/169#issuecomment-495193902[Toolbox Github Repo]
+TIP: The following workaround might be useful for other `toolbox` errors caused by `podman` versions greater than `1.2.0`.
+     See https://github.com/debarshiray/toolbox/issues/169#issuecomment-495193902[Toolbox Github Repo]
 
 As a workaround, it is possible to override `podman` packages newer than version `1.2.0` by issuing:
 
@@ -164,7 +143,7 @@ As a workaround, it is possible to override `podman` packages newer than version
 
 Reboot the system to apply the changes.
 
-For reference, it is also possible to override the package by following these steps: 
+For reference, it is also possible to override the package by following these steps:
 
 . Download `podman-1.2.0-2.git3bd528e.fc30.x86_64.rpm` from https://kojipkgs.fedoraproject.org//packages/podman/1.2.0/2.git3bd528e.fc30/x86_64/podman-1.2.0-2.git3bd528e.fc30.x86_64.rpm[Koji]
 . Remove `podman-manpages` issuing: `rpm-ostree override remove podman-manpages`
@@ -180,9 +159,8 @@ To revert this workaround issue the following command:
 
 https://github.com/containers/libpod/issues/3187[GitHub Issue]
 
-With certain versions of `podman`, trying to enter a toolbox will result in
-errors. You can fix this by resetting the permissions on the overlay-containers
-with the following command.
+With certain versions of `podman`, trying to enter a toolbox will result in errors.
+You can fix this by resetting the permissions on the overlay-containers with the following command.
 
  $ sudo chown -R $USER ~/.local/share/containers/storage/overlay-containers
 
@@ -190,17 +168,17 @@ This will reset the permissions on your containers and allow you to enter them a
 
 == Running `restorecon`
 
-WARNING: You should never run `restorecon` on a {variant-name} host. See the following
-bug for details - https://bugzilla.redhat.com/show_bug.cgi?id=1259018
+WARNING: You should never run `restorecon` on a {variant-name} host.
+         See the following bug for details - https://bugzilla.redhat.com/show_bug.cgi?id=1259018
 
 However, if you happened to do this, it is possible to recover.
 
-1.  Boot with `enforcing=0` on the kernel command line
-2.  Create a new, "fixed" commit locally
-3.  Deploy the new "fixed" commit
-4.  Run `restorecon`
-5.  Reboot
-6.  Cleanup
+1. Boot with `enforcing=0` on the kernel command line
+2. Create a new, "fixed" commit locally
+3. Deploy the new "fixed" commit
+4. Run `restorecon`
+5. Reboot
+6. Cleanup
 
  $ rpm-ostree status -b | grep BaseCommit
                  BaseCommit: 696991d589980aeaef5eda352dd7ad3d33c444c789c209f793a84bc6e7269aee
@@ -212,7 +190,6 @@ However, if you happened to do this, it is possible to recover.
  $ sudo ostree admin deploy fedora:fedora/35/x86_64/{variant}
  $ sudo reboot
 
-The caveat to this recovery is that your layered packages will be removed; you'll
-need to relayer them after the recovery.
+The caveat to this recovery is that your layered packages will be removed; you'll need to relayer them after the recovery.
 
-See this upstream comment for additional details - https://github.com/ostreedev/ostree/issues/1265#issuecomment-484557615
+See this upstream comment for additional details: https://github.com/ostreedev/ostree/issues/1265#issuecomment-484557615

--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -1,73 +1,59 @@
 [[updates-upgrades-rollbacks]]
 = Updates, Upgrades & Rollbacks
 
-Installing updates with {variant-name} is easy and fast (much faster than other
-operating systems). It also has a special rollback feature, in case anything
-goes wrong.
+Installing updates with {variant-name} is easy and fast (much faster than other operating systems).
+It also has a special rollback feature, in case anything goes wrong.
 
 [[updating]]
 == Updating {variant-name}
 
-OS updates in {variant-name} are fully integrated into the desktop; you will be
-automatically notified when an update is available. The standard behavior is to
-automatically download the update (this can be changed from the update
-preferences in Software).
+OS updates in {variant-name} are fully integrated into the desktop; you will be automatically notified when an update is available.
+The standard behavior is to automatically download the update (this can be changed from the update preferences in Software).
 
-Once an update is ready, it is just a matter of rebooting to start using the
-new version. There is no waiting for the update to be installed during this
-reboot.
+Once an update is ready, it is just a matter of rebooting to start using the new version.
+There is no waiting for the update to be installed during this reboot.
 
-If you'd prefer, it is also possible to update using the command line. To do
-this, run:
+If you'd prefer, it is also possible to update using the command line.
+To do this, run:
 
  $ rpm-ostree upgrade
 
-This will check for new updates and download and install them if they are
-available. Alternatively, to check for available updates without downloading
-them, run:
+This will check for new updates and download and install them if they are available.
+Alternatively, to check for available updates without downloading them, run:
 
  $ rpm-ostree upgrade --check
 
 [[upgrading]]
 == Upgrading between major versions
 
-Upgrading between major versions (such as from Fedora 34 to Fedora 35) can be
-completed using the Software application. Alternatively, {variant-name} can be
-upgraded between major versions using the `ostree` command.
+Upgrading between major versions (such as from Fedora 34 to Fedora 35) can be completed using the Software application.
+Alternatively, {variant-name} can be upgraded between major versions using the `ostree` command.
 
-First, verify the branch is available. You can print all available branches
-with this command:
+First, verify the branch is available.
+You can print all available branches with this command:
 
  $ ostree remote refs fedora | grep {variant}
 
-After you verify the name of your branch, you are ready to proceed. For
-example, to upgrade to {variant-name} 35, the command is:
+After you verify the name of your branch, you are ready to proceed.
+For example, to upgrade to {variant-name} 35, the command is:
 
-NOTE: Currently, the default remote for {variant-name} 35 is named `fedora`. If
-this is not the case for your system, you can find out the remote name by
-issuing: `ostree remote list`.
+NOTE: Currently, the default remote for {variant-name} 35 is named `fedora`.
+      If this is not the case for your system, you can find out the remote name by issuing: `ostree remote list`.
 
  $ rpm-ostree rebase fedora:fedora/35/x86_64/{variant}
 
-The process is very similar to a system update: the new OS is downloaded and
-installed in the background, and you just boot into it when it is ready.
+The process is very similar to a system update: the new OS is downloaded and installed in the background, and you just boot into it when it is ready.
 
 [[rolling-back]]
 == Rolling back
 
-{variant-name} keeps a record of the previous OS version, which can be switched to
-instead of the latest version. While this shouldn't usually be necessary, it
-can be helpful if there is a problem with an update or an upgrade (rollbacks
-work the same way for both), as well as for development purposes.
+{variant-name} keeps a record of the previous OS version, which can be switched to instead of the latest version.
+While this shouldn't usually be necessary, it can be helpful if there is a problem with an update or an upgrade (rollbacks work the same way for both), as well as for development purposes.
 
 There are two ways to roll back to the previous version:
 
-. Temporary rollbacks: to temporarily roll back to a previous version, simply
-  reboot and select the previous version from the boot menu (often known as the
-  grub menu).
-. Permanent rollbacks: to permanently switch back to the previous deployment,
-  use the `rpm-ostree rollback` command.
+. Temporary rollbacks: to temporarily roll back to a previous version, simply reboot and select the previous version from the boot menu (often known as the grub menu).
+. Permanent rollbacks: to permanently switch back to the previous deployment, use the `rpm-ostree rollback` command.
 
-After rolling back, you will technically be on an old OS version, and may be
-prompted to update. Updating will undo the rollback, so should be avoided if
-you want the rollback to stay in effect.
+After rolling back, you will technically be on an old OS version, and may be prompted to update.
+Updating will undo the rollback, so should be avoided if you want the rollback to stay in effect.


### PR DESCRIPTION
See individual commits for a readable diff.

Align the style for the entire documentation to prefer one sentence per line. This has the following advantages:
- Asciidoc properly combines lines of text into a single paragraph
- This keeps the Git diff readable and minimal while keeping line lengths reasonable
- Some Asciidoc functionnality does not interact well with hard wrapped lines