### PR TITLE
Create entities.adoc to hold variables' values

### DIFF
--- a/modules/ROOT/pages/_partials/entities.adoc
+++ b/modules/ROOT/pages/_partials/entities.adoc
@@ -1,0 +1,11 @@
+:variant-name: Silverblue
+
+:website: https://silverblue.fedoraproject.org/
+
+:docs-issue: https://github.com/fedora-silverblue/silverblue-docs/issues
+
+:docs-src: https://github.com/fedora-silverblue/silverblue-docs
+
+:issue-tracker: https://github.com/fedora-silverblue/silverblue-docs/issues
+
+:discussion-forum: https://discussion.fedoraproject.org/tags/c/project/7/silverblue


### PR DESCRIPTION
Not setting these variables somewhere result in the variables names being shown up in the built documentation as of 9b1eb7a9.