### PR TITLE
Move asciidoc attributes to antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -14,3 +14,14 @@ start_page: ROOT:index.adoc
 # This lists all the menu definitions of your component.
 nav:
 - modules/ROOT/nav.adoc
+
+asciidoc:
+  attributes:
+    variant: silverblue
+    variant-name: Silverblue
+    website: https://silverblue.fedoraproject.org/
+    issue-tracker: https://github.com/fedora-silverblue/issue-tracker/issues
+    docs-url: https://docs.fedoraproject.org/en-US/fedora-silverblue/
+    docs-src: https://github.com/fedora-silverblue/silverblue-docs
+    docs-issue: https://github.com/fedora-silverblue/silverblue-docs/issues
+    discussion-forum: https://discussion.fedoraproject.org/c/desktop/silverblue

--- a/site.yml
+++ b/site.yml
@@ -18,13 +18,3 @@ output:
 runtime:
   fetch: true
   cache_dir: ./cache
-asciidoc:
-  attributes:
-    variant: silverblue
-    variant-name: Silverblue
-    website: https://silverblue.fedoraproject.org/
-    issue-tracker: https://github.com/fedora-silverblue/issue-tracker/issues
-    docs-url: https://docs.fedoraproject.org/en-US/fedora-silverblue/
-    docs-src: https://github.com/fedora-silverblue/silverblue-docs
-    docs-issue: https://github.com/fedora-silverblue/silverblue-docs/issues
-    discussion-forum: https://discussion.fedoraproject.org/c/desktop/silverblue


### PR DESCRIPTION
This should fix the substitution on the Fedora built & hosted version of the docs.

Thanks for Rafael Fontenelle @rffontenelle for the report.