### PR TITLE
Use a variable to set the Fedora 36 version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -19,6 +19,7 @@ asciidoc:
   attributes:
     variant: silverblue
     variant-name: Silverblue
+    version: 36
     website: https://silverblue.fedoraproject.org/
     issue-tracker: https://github.com/fedora-silverblue/issue-tracker/issues
     docs-url: https://docs.fedoraproject.org/en-US/fedora-silverblue/

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -180,15 +180,18 @@ However, if you happened to do this, it is possible to recover.
 5. Reboot
 6. Cleanup
 
- $ rpm-ostree status -b | grep BaseCommit
-                 BaseCommit: 696991d589980aeaef5eda352dd7ad3d33c444c789c209f793a84bc6e7269aee
- $ sudo ostree checkout -H 696991d589980aeaef5eda352dd7ad3d33c444c789c209f793a84bc6e7269aee /ostree/repo/tmp/selinux-fix
- $ sudo ostree fsck --delete
- $ sudo ostree commit --consume --link-checkout-speedup --orphan --selinux-policy=/ /ostree/repo/tmp/selinux-fix
- $ sudo restorecon -Rv /var
- $ sudo restorecon -Rv /etc
- $ sudo ostree admin deploy fedora:fedora/35/x86_64/{variant}
- $ sudo reboot
+[source,bash,subs="attributes"]
+----
+$ rpm-ostree status -b | grep BaseCommit
+                BaseCommit: 696991d589980aeaef5eda352dd7ad3d33c444c789c209f793a84bc6e7269aee
+$ sudo ostree checkout -H 696991d589980aeaef5eda352dd7ad3d33c444c789c209f793a84bc6e7269aee /ostree/repo/tmp/selinux-fix
+$ sudo ostree fsck --delete
+$ sudo ostree commit --consume --link-checkout-speedup --orphan --selinux-policy=/ /ostree/repo/tmp/selinux-fix
+$ sudo restorecon -Rv /var
+$ sudo restorecon -Rv /etc
+$ sudo ostree admin deploy fedora:fedora/{version}/x86_64/{variant}
+$ sudo reboot
+----
 
 The caveat to this recovery is that your layered packages will be removed; you'll need to relayer them after the recovery.
 

--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -26,21 +26,27 @@ Alternatively, to check for available updates without downloading them, run:
 [[upgrading]]
 == Upgrading between major versions
 
-Upgrading between major versions (such as from Fedora 34 to Fedora 35) can be completed using the Software application.
+Upgrading between major versions (such as from Fedora 35 to Fedora 36) can be completed using the Software application.
 Alternatively, {variant-name} can be upgraded between major versions using the `ostree` command.
 
 First, verify the branch is available.
 You can print all available branches with this command:
 
- $ ostree remote refs fedora | grep {variant}
+[source,bash,subs="attributes"]
+----
+$ ostree remote refs fedora | grep {variant}
+----
 
 After you verify the name of your branch, you are ready to proceed.
-For example, to upgrade to {variant-name} 35, the command is:
+For example, to upgrade to {variant-name} {version}, the command is:
 
-NOTE: Currently, the default remote for {variant-name} 35 is named `fedora`.
+NOTE: Currently, the default remote for {variant-name} {version} is named `fedora`.
       If this is not the case for your system, you can find out the remote name by issuing: `ostree remote list`.
 
- $ rpm-ostree rebase fedora:fedora/35/x86_64/{variant}
+[source,bash,subs="attributes"]
+----
+$ rpm-ostree rebase fedora:fedora/{version}/x86_64/{variant}
+----
 
 The process is very similar to a system update: the new OS is downloaded and installed in the background, and you just boot into it when it is ready.
 


### PR DESCRIPTION
Fix some variable usage in code blocks and add version variable.

~Currently on top of https://github.com/fedora-silverblue/silverblue-docs/pull/124 for simplicity. Will be easier to review once #124 is merged.~