### PR TITLE
Use Fedora Silverblue consistently & small updates-upgrades-rollbacks style fixes

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,9 +1,9 @@
 # Name will be mostly visible in the URL. Treat it as an indentifier.
 # Tip: If you want to use the local preview scripts that come with this repository, please change this value in the site.yml file as well. (under site/start_page)
-name: fedora-silverblue  # <---- PLEASE MODIFY
+name: fedora-silverblue
 
 # Title will be visible on the page.
-title: Fedora Silverblue # <---- PLEASE MODIFY
+title: Fedora Silverblue
 
 # If you don't plan to have multiple versions of the docs (for example, to document multiple versions of some software), you can ignore this field. Otherwise, change "master" to a specific version.
 version: master
@@ -17,12 +17,12 @@ nav:
 
 asciidoc:
   attributes:
-    variant: silverblue
-    variant-name: Silverblue
+    variant: "silverblue"
+    variant-name: "Fedora Silverblue"
     version: 36
-    website: https://silverblue.fedoraproject.org/
-    issue-tracker: https://github.com/fedora-silverblue/issue-tracker/issues
-    docs-url: https://docs.fedoraproject.org/en-US/fedora-silverblue/
-    docs-src: https://github.com/fedora-silverblue/silverblue-docs
-    docs-issue: https://github.com/fedora-silverblue/silverblue-docs/issues
-    discussion-forum: https://discussion.fedoraproject.org/c/desktop/silverblue
+    website: "https://silverblue.fedoraproject.org/"
+    issue-tracker: "https://github.com/fedora-silverblue/issue-tracker/issues"
+    docs-url: "https://docs.fedoraproject.org/en-US/fedora-silverblue/"
+    docs-src: "https://github.com/fedora-silverblue/silverblue-docs"
+    docs-issue: "https://github.com/fedora-silverblue/silverblue-docs/issues"
+    discussion-forum: "https://discussion.fedoraproject.org/c/desktop/silverblue"

--- a/modules/ROOT/pages/contributing.adoc
+++ b/modules/ROOT/pages/contributing.adoc
@@ -1,12 +1,12 @@
 [[contributing]]
-= Contributing to Fedora {variant-name}
+= Contributing to {variant-name}
 
-Help us improve Fedora {variant-name} by contributing to the project!
+Help us improve {variant-name} by contributing to the project!
 
 [[developing]]
 == Developing {variant-name}
 
-If you are a developer, you can contribute to one of the several projects which make Fedora {variant-name} possible.
+If you are a developer, you can contribute to one of the several projects which make {variant-name} possible.
 Submit your pull requests to:
 
 * https://github.com/projectatomic/rpm-ostree[rpm-ostree]

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -18,7 +18,7 @@ Is Silverblue another GNOME OS?::
     However, the two efforts do share a desire to deliver a user experience that is polished and coherent.
 
 What is {variant-name}'s relationship with Project Atomic?::
-    Fedora {variant-name} uses the same core technology as Fedora Atomic Host (as well as its successor, Fedora CoreOS).
+    {variant-name} uses the same core technology as Fedora Atomic Host (as well as its successor, Fedora CoreOS).
     However, {variant-name} is specifically focused on workstation/desktop use cases.
 
 == About using {variant-name}
@@ -67,7 +67,7 @@ However, you can use `toolbox` with the following command:
 
  $ toolbox run dnf search <package>
 +
-NOTE: The assumption is that you have already created a toolbox matching the version of your Fedora {variant-name} installation.
+NOTE: The assumption is that you have already created a toolbox matching the version of your {variant-name} installation.
 
 How can I downgrade my system's kernel?::
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -20,14 +20,14 @@ See the dedicated xref:toolbox.adoc[toolbox] page to get started with it.
 == Flatpak
 
 Flatpak is the primary way that apps can be installed on {variant-name} (for more information, see http://flatpak.org[flatpak.org]).
-Flatpak works out of the box in Fedora {variant-name}, and Fedora provides a small (but growing) collection of apps that can be installed.
+Flatpak works out of the box in {variant-name}, and Fedora provides a small (but growing) collection of apps that can be installed.
 
 The other main source of Flatpak apps is https://flathub.org/home[Flathub], which provides a large repository of Flatpak apps that can be installed.
 
 [[flathub-setup]]
 == Setting up Flathub
 
-To setup Flathub on Fedora {variant-name}, open the https://flatpak.org/setup/Fedora/[Flathub setup page for Fedora] and click the “Flathub repository file” button to download the Flathub configuration.
+To setup Flathub on {variant-name}, open the https://flatpak.org/setup/Fedora/[Flathub setup page for Fedora] and click the “Flathub repository file” button to download the Flathub configuration.
 
 image::sfg_flathub_fedora.png[title="Fedora quick setup page"]
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,10 +1,10 @@
-= Fedora {variant-name} User Guide
+= {variant-name} User Guide
 
-Welcome to the Fedora {variant-name} user guide!
+Welcome to the {variant-name} user guide!
 
 image::silverblue-logo.svg[{variant-name} logo]
 
-_Fedora {variant-name}_ is an immutable desktop operating system.
+_{variant-name}_ is an immutable desktop operating system.
 It aims to be extremely stable and reliable.
 It also aims to be an excellent platform for developers and for those using container-focused workflows.
 

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -1,6 +1,6 @@
 = Installing {variant-name}
 
-Fedora {variant-name} can be installed in the same way as Fedora Workstation, and the official Fedora installation guide can be followed for your Fedora version.
+{variant-name} can be installed in the same way as Fedora Workstation, and the official Fedora installation guide can be followed for your Fedora version.
 See the https://docs.fedoraproject.org/en-US/docs/[Fedora documentation site] for more details.
 
 [[before-you-begin]]

--- a/modules/ROOT/pages/toolbox.adoc
+++ b/modules/ROOT/pages/toolbox.adoc
@@ -9,7 +9,7 @@ As an immutable host, {variant-name} is an excellent platform for container-base
 == Why use toolbox?
 
 Toolbox makes it easy to use a containerized environment for everyday software development and debugging.
-On immutable operating systems, like {website}[Fedora {variant-name}], it provides a familiar package-based environment in which tools and libraries can be installed and used.
+On immutable operating systems, like {website}[{variant-name}], it provides a familiar package-based environment in which tools and libraries can be installed and used.
 However, toolbox can also be used on package-based systems.
 
 Using Toolbox for running your workflows in a containerized manner brings you several advantages:
@@ -50,9 +50,9 @@ One example of this is the toolbox command itself; this makes it possible to use
 [[toolbox-installation]]
 == Installation
 
-=== Fedora {variant-name}
+=== {variant-name}
 
-Toolbox is preinstalled on Fedora {variant-name} 30 or newer.
+Toolbox is preinstalled on {variant-name} 30 or newer.
 On older versions, it can be installed with the following command:
 
  $ rpm-ostree install toolbox

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -117,7 +117,7 @@ A couple of possible workarounds exist:
 
 * During the install process, select "Custom Partitioning" and create an additional EFI partition.
   Assign the newly created EFI partition to `/boot/efi`.
-  You will then be able to boot the previous OS(s) alongside Fedora {variant-name}.
+  You will then be able to boot the previous OS(s) alongside {variant-name}.
   If this workaround is not successful follow the below step.
 * Reformat the EFI partition on the host during the install process.
   This can be done by selecting "Custom Partitioning" and checking the `Reformat` box when creating the `/boot/efi` partition.

--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -51,9 +51,13 @@ $ rpm-ostree rebase fedora:fedora/{version}/x86_64/{variant}
 
 The process is very similar to a system update: the new OS is downloaded and installed in the background, and you just boot into it when it is ready.
 
-Additionally, you can choose to rebase to a different immutable variant of Fedora, like for example Fedora Kinoite. Kinoite is similar to Silverblue, except for the fact that it uses the KDE Plasma desktop environment instead of the default GNOME desktop environment. 
+Additionally, you can choose to rebase to a different immutable variant of Fedora, like for example Fedora Kinoite.
+Fedora Kinoite is similar to {variant-name}, except for the fact that it uses the KDE Plasma desktop environment instead of the default GNOME desktop environment.
 
-What this means is, you can rebase to Fedora Kinoite to try it out, without ever touching your current system. Because the two system images are isolated from eachother, the two desktop environments will never be installed at the same time. All of your flatpak apps and /home files will stay persistent between rebases. Same applies for testing out the bleeding-edge version of Silverblue, which is Rawhide.
+What this means is, you can rebase to Fedora Kinoite to try it out, without ever touching your current system.
+Because the two system images are isolated from eachother, the two desktop environments will never be installed at the same time.
+All of your flatpak apps and /home files will stay persistent between rebases.
+Same applies for testing out the bleeding-edge version of {variant-name}, which is Rawhide.
 
 If you decide to rebase, make sure to https://docs.fedoraproject.org/en-US/fedora-silverblue/faq/#_about_using_silverblue[pin] your current deployment, so you don't accidentaly lose it (by default, only the two most recent deployments are kept).
 


### PR DESCRIPTION
Small fixes found during the manual sync with the Kinoite docs.

Fixes: https://github.com/fedora-silverblue/silverblue-docs/pull/134

---

updates-upgrades-rollbacks: Minor style fixes

---

*: Use Fedora Silverblue consistently as name

Make sure that we always use the full name.