### PR TITLE
tips&tricks: Hide the default browser in the interface

### DIFF
--- a/modules/ROOT/pages/tips-and-tricks.adoc
+++ b/modules/ROOT/pages/tips-and-tricks.adoc
@@ -11,6 +11,37 @@ $ sudo sed -i "2a\\NotShowIn=GNOME;KDE" /usr/local/share/applications/firefox.de
 $ sudo update-desktop-database /usr/local/share/applications/
 ```
 
+== Enabling RPM Fusion repos
+
+[CAUTION]
+====
+This section discusses third-party software sources not officially affiliated with or endorsed by the Fedora Project.
+Use them at your own discretion.
+Fedora recommends the use of free and open source software and avoidance of software encumbered by patents.
+====
+
+Users may want to take advantage of the non-free software that is made available via the https://rpmfusion.org/[RPM Fusion] repos in order to use the proprietary NVIDIA drivers, multimedia codecs, or other software not distributed as part of Fedora.
+
+The first time you install the RPM Fusion repos, you need to install the versioned RPMs:
+
+    $ sudo rpm-ostree install \
+        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+    $ reboot
+
+
+Once you have rebooted into the new deployment, you can run the following command to remove the “lock” on the versioned packages that were installed previously.
+This will enable the RPM Fusion repos to be automatically updated and versioned correctly across major Fedora version rebases:
+
+    $ sudo rpm-ostree update \
+        --uninstall rpmfusion-free-release \
+        --uninstall rpmfusion-nonfree-release \
+        --install rpmfusion-free-release \
+        --install rpmfusion-nonfree-release
+    $ reboot
+
+For more information, see https://discussion.fedoraproject.org/t/simplifying-updates-for-rpm-fusion-packages-and-other-packages-shipping-their-own-rpm-repos/30364[this thread] on the Fedora Discourse site.
+
 == Working with Toolbx
 
 === Finding out if you are currently in a Toolbx container
@@ -129,37 +160,3 @@ or setup shell `alias`es as needed to make them available to the CLI like so:
   $ alias evince="flatpak run org.gnome.Evince"
     # or alias evince="org.gnome.Evince"
   $ evince
-
-== Enabling RPM Fusion repos
-
-[CAUTION]
-====
-This section discusses third-party software sources not officially affiliated with or endorsed by the Fedora Project.
-Use them at your own discretion.
-Fedora recommends the use of free and open source software and avoidance of software encumbered by patents.
-====
-
-Users may want to take advantage of the non-free software that is made available via the https://rpmfusion.org/[RPM Fusion]
-repos in order to use the proprietary NVIDIA drivers, multimedia codecs, or other software not
-distributed as part of Fedora.
-
-The first time you install the RPM Fusion repos, you need to install the versioned RPMs:
-
-    $ sudo rpm-ostree install \
-        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
-        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
-    $ reboot
-
-
-Once you have rebooted into the new deployment, you can run the following command to remove
-the “lock” on the versioned packages that were installed previously. This will enable the
-RPM Fusion repos to be automatically updated and versioned correctly across major Fedora version rebases:
-
-    $ sudo rpm-ostree update \
-        --uninstall rpmfusion-free-release \
-        --uninstall rpmfusion-nonfree-release \
-        --install rpmfusion-free-release \
-        --install rpmfusion-nonfree-release
-    $ reboot
-
-For more information, see https://discussion.fedoraproject.org/t/simplifying-updates-for-rpm-fusion-packages-and-other-packages-shipping-their-own-rpm-repos/30364[this thread] on the Fedora Discourse site.

--- a/modules/ROOT/pages/tips-and-tricks.adoc
+++ b/modules/ROOT/pages/tips-and-tricks.adoc
@@ -1,5 +1,16 @@
 = Tips and Tricks
 
+== Hidding the default browser (Firefox)
+
+If you're using another browser than the one installed by default (Firefox) then you can hide the default one from the interface via the following commands:
+
+```
+$ sudo mkdir -p /usr/local/share/applications/
+$ sudo cp /usr/share/applications/firefox.desktop /usr/local/share/applications/
+$ sudo sed -i "2a\\NotShowIn=GNOME;KDE" /usr/local/share/applications/firefox.desktop
+$ sudo update-desktop-database /usr/local/share/applications/
+```
+
 == Working with Toolbx
 
 === Finding out if you are currently in a Toolbx container


### PR DESCRIPTION
Add instructions to hide the default browser installed in the image from the menues in the interface.
    
This is better than using `rpm-ostree override remove` as it does not mutate the image and keeps updates fast.