### PR TITLE
Add instructions for replacing fedora-flatpak remote with flathub

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -101,3 +101,20 @@ NOTE: `0` here refers to the first deployment listed by `rpm-ostree status`
 The GRUB menu will now present you with both: the previous deployment major version entry (e.g.: *"Fedora 30.YYYYMMDD.n"*) and the new deployment major version entry (e.g.: *"Fedora 31.YYYYMMDD.n"*).
 +
 NOTE: At the moment it is not possible to name (pinned) deployments and their associated GRUB menu entries.
+
+How do to replace fedora-flatpak remote with flathub?::
+
+. Enable the flathub remote if not already enabled using the instructions {docs-url}/getting-started/#flathub-setup[here]
+
+. Run this command to reinstall fedora flatpak repo applications with ones from flathub
+
+ $ flatpak install --reinstall flathub $(flatpak list --app-runtime=org.fedoraproject.Platform --columns=application | tail -n +1 )
+
+. Then finally, remove the fedora flatpak repo.
+
+ $ flatpak remote-delete fedora
+
++
+
+NOTE: Make sure that the only thing prompted for removal is the runtime, if any other application is listed, run +
+ `flatpak install --reinstall flathub name.of.application`


### PR DESCRIPTION
The flathub repository often has more up to date versions of applications.
As a result, one might want to remove the fedora flatpak remote entirely
