### PR TITLE
Replace absolute links with xrefs

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -81,7 +81,7 @@ If, for whatever reason, you need to downgrade the kernel, you can do so by foll
 
 . Reboot the system to apply the changes.
 
-How can I upgrade my system to the next major version (for instance: rawhide or an upcoming Fedora release branch), while keeping my current deployment?::
+[[pinning]]How can I upgrade my system to the next major version (for instance: rawhide or an upcoming Fedora release branch), while keeping my current deployment?::
 
 OSTree allows you to pin deployments (pinning ensures that your deployment of choice is kept and not discarded).
 
@@ -95,7 +95,7 @@ NOTE: `0` here refers to the first deployment listed by `rpm-ostree status`
 
  rpm-ostree status
 
-. After the deployment is pinned, you can upgrade your system by using the instructions found {docs-url}/updates-upgrades-rollbacks/#upgrading[here].
+. After the deployment is pinned, you can upgrade your system by using the instructions found xref:updates-upgrades-rollbacks.adoc#upgrading[here].
 
 . When you have completed rebasing, reboot the system.
 The GRUB menu will now present you with both: the previous deployment major version entry (e.g.: *"Fedora 30.YYYYMMDD.n"*) and the new deployment major version entry (e.g.: *"Fedora 31.YYYYMMDD.n"*).

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -32,9 +32,9 @@ With {variant-name}, it is also possible to roll back to the previous version of
 In most cases, {variant-name} behaves like a standard Fedora Workstation installation, and the https://docs.fedoraproject.org/[standard Fedora documentation] can be used.
 This guide covers those areas where {variant-name} differs from a standard Fedora Workstation, including:
 
-* link:installation[OS installation]
-* link:getting-started[Installing apps and software]
-* link:updates-upgrades-rollbacks[OS upgrades and rollbacks]
+* xref:installation.adoc[OS installation]
+* xref:getting-started.adoc[Installing apps and software]
+* xref:updates-upgrades-rollbacks.adoc[OS upgrades and rollbacks]
 
 The primary audience for these docs are new users, who aren't expected to have specialist knowledge or technical knowledge about {variant-name}'s internals.
-However, some background link:technical-information[technical information] is provided, for those who are interested and want to learn more.
+However, some background xref:technical-information.adoc[technical information] is provided, for those who are interested and want to learn more.

--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -70,7 +70,7 @@ Because the two system images are isolated from eachother, the two desktop envir
 All of your flatpak apps and /home files will stay persistent between rebases.
 Same applies for testing out the bleeding-edge version of {variant-name}, which is Rawhide.
 
-If you decide to rebase, make sure to https://docs.fedoraproject.org/en-US/fedora-silverblue/faq/#_about_using_silverblue[pin] your current deployment, so you don't accidentaly lose it (by default, only the two most recent deployments are kept).
+If you decide to rebase, make sure to xref:faq.adoc#pinning[pin] your current deployment, so you don't accidentaly lose it (by default, only the two most recent deployments are kept).
 
 [[rolling-back]]
 == Rolling back


### PR DESCRIPTION
There's two broken links I found that could be easily replaced with `xref:` &mdash; `{docs-url}/something` results in a duplicate `/` ([`https://docs.fedoraproject.org/en-US/fedora-silverblue//updates-upgrades-rollbacks/#upgrading`](https://docs.fedoraproject.org/en-US/fedora-silverblue//updates-upgrades-rollbacks/#upgrading)) and breaks the relative CSS style links.
In addition, I made sure that deployment pinning link goes to the right location in the page and does not depend on the variant name.

After the change there's no remaining references to the `{docs-url}` variable. It could be removed to prevent reappearance of such links.