### PR TITLE
installation: Use code block for commands

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -105,11 +105,11 @@ NOTE: `0` here refers to the first deployment listed by `rpm-ostree status`
 
 . Verify that you have pinned your deployment of choice by issuing:
 
- rpm-ostree status
+ $ rpm-ostree status
 
 . After the deployment is pinned, you can upgrade your system by using the instructions found xref:updates-upgrades-rollbacks.adoc#upgrading[here].
 
 . When you have completed rebasing, reboot the system.
-The GRUB menu will now present you with both: the previous deployment major version entry (e.g.: *"Fedora 30.YYYYMMDD.n"*) and the new deployment major version entry (e.g.: *"Fedora 31.YYYYMMDD.n"*).
+The GRUB menu will now present you with both: the previous deployment major version entry (e.g.: *"Fedora {version-oldstable}.YYYYMMDD.n"*) and the new deployment major version entry (e.g.: *"Fedora {version-stable}.YYYYMMDD.n"*).
 +
 NOTE: At the moment it is not possible to name (pinned) deployments and their associated GRUB menu entries.

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -27,7 +27,8 @@ However, there are hazards involved in both cases, and you should only attempt t
 
 Regardless of your selection during the installation process, the keyboard layout available for the LUKS unlock screen will default to `en-US` (English - United States of America).
 You can workaround this issue by running the following command on the first boot after the installation:
- `rpm-ostree initramfs-etc --track=/etc/vconsole.conf`.
+
+  # rpm-ostree initramfs-etc --track=/etc/vconsole.conf
 
 To avoid struggling when having to type the LUKS passphrase for the first time, you could set during installation a disk encryption passphrase that is easy to type with the `en-US` keyboard layout, and then change it to the passphrase that you actually want through the GNOME https://apps.gnome.org/en-GB/app/org.gnome.DiskUtility[Disks] app.
 

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -23,6 +23,8 @@ If you are uncertain about this, {variant-name} can also be tested in a virtual 
 It is possible to make {variant-name} work for both dual boot and manual partitioning, and some guidance is provided on manual partitioning below.
 However, there are hazards involved in both cases, and you should only attempt to use these features if you have done the necessary research, and are confident that you can overcome any issues that you might encounter.
 
+This issue is tracked in https://github.com/fedora-silverblue/issue-tracker/issues/284[issue #284].
+
 *The keyboard layout selected during installation is not used for the LUKS unlock screen of {variant-name}.*
 
 Regardless of your selection during the installation process, the keyboard layout available for the LUKS unlock screen will default to `en-US` (English - United States of America).

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -30,7 +30,7 @@ This issue is tracked in https://github.com/fedora-silverblue/issue-tracker/issu
 Regardless of your selection during the installation process, the keyboard layout available for the LUKS unlock screen will default to `en-US` (English - United States of America).
 You can workaround this issue by running the following command on the first boot after the installation:
 
-  # rpm-ostree initramfs-etc --track=/etc/vconsole.conf
+  $ rpm-ostree initramfs-etc --track=/etc/vconsole.conf
 
 To avoid struggling when having to type the LUKS passphrase for the first time, you could set during installation a disk encryption passphrase that is easy to type with the `en-US` keyboard layout, and then change it to the passphrase that you actually want through the GNOME https://apps.gnome.org/en-GB/app/org.gnome.DiskUtility[Disks] app.
 

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -37,12 +37,10 @@ NOTE: The https://universal-blue.org/[Universal Blue] project creates operating 
 . Then setup the RPM Fusion repositories following the https://docs.fedoraproject.org/en-US/quick-docs/setup_rpmfusion/#proc_enabling-the-rpmfusion-repositories-for-ostree-based-systems_enabling-the-rpmfusion-repositories[documentation], including the two reboots.
 
 . Finally, install the drivers:
-+
+
  # rpm-ostree install kmod-nvidia xorg-x11-drv-nvidia
  # rpm-ostree kargs --append=rd.driver.blacklist=nouveau --append=modprobe.blacklist=nouveau --append=nvidia-drm.modeset=1
  # systemctl reboot
-+
-
 
 NOTE: When using Secure Boot, the locally installed NVIDIA drivers have to be signed with a local key that is enrolled using `mokutil`. See the https://github.com/fedora-silverblue/issue-tracker/issues/272[fedora-silverblue#272] issue for more details.
 

--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -88,3 +88,29 @@ There are two ways to roll back to the previous version:
 
 After rolling back, you will technically be on an old OS version, and may be prompted to update.
 Updating will undo the rollback, so should be avoided if you want the rollback to stay in effect.
+
+`rpm-ostree` only keeps one rollback version available by default.
+If you want to rollback to another version that the one currently available on your system, you can do so with the following commands:
+
+. Pull the ostree commit log from the remote repository:
++
+[source,bash,subs="attributes"]
+----
+$ sudo ostree pull --commit-metadata-only --depth=10 fedora fedora/{version-stable}/x86_64/silverblue
+----
+
+. Display the log:
++
+[source,bash,subs="attributes"]
+----
+$ ostree log fedora:fedora/{version-stable}/x86_64/{variant}
+----
+
+. Deploy a specific commit:
++
+[source,bash,subs="attributes"]
+----
+$ rpm-ostree deploy {version-stable}.20230716.0
+----
+
+Note that this will deploy the exact version as requested and will not include overlayed packages and other changes.


### PR DESCRIPTION
installation: Use code block for commands

---

installation: Add link to dual boot issue

---

fixup! installation: Use code block for commands

---

troubleshooting: Remove unneeded list continuation '+'

---

faq: Update versions to variables

Also set '$' for commands.

---

updates-upgrades-rollbacks: Add more rollback examples

Add an example that fetches the ostree log and deploys an arbitrary
version from the repo.

Fixes: https://github.com/fedora-silverblue/silverblue-docs/issues/155