### PR TITLE
antora: update for Fedora 39 release

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -25,8 +25,8 @@ asciidoc:
   attributes:
     variant: "silverblue"
     variant-name: "Fedora Silverblue"
-    version-stable: 38
-    version-oldstable: 37
+    version-stable: 39
+    version-oldstable: 38
     update-application: "GNOME Software"
     website: "https://silverblue.fedoraproject.org/"
     issue-tracker: "https://github.com/fedora-silverblue/issue-tracker/issues"


### PR DESCRIPTION
Noticed while syncing our docs for release.
I'd bump sericea-docs directly, but making the change here and merging it to our downstream is a better approach :smiley: