### PR TITLE
fix #169 : mention rpm-ostree search function

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -107,7 +107,7 @@ Packages can be installed on {variant-name} using:
  $ rpm-ostree install <package name>
 
 This will download the package and any required dependencies, and recompose your {variant-name} image with them.
-`rpm-ostree` uses standard Fedora package names, which can be searched using DNF (this is not available on a {variant-name} host, but can be used in a xref:toolbox.adoc[toolbox]).
+`rpm-ostree` uses standard Fedora package names, which can be searched with `rpm-ostree search` since {variant-name} 39, or using DNF inside a xref:toolbox.adoc[toolbox] for previous versions.
 
 Once a package has been installed in this manner, it will be kept up-to-date as new versions are released and as the base operating system is updated.
 


### PR DESCRIPTION
fix #169 
context: https://fedoramagazine.org/searching-for-packages-with-rpm-ostree-search/