### PR TITLE
docs: add initcall_blacklist to kargs

### DIFF
--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -39,7 +39,7 @@ NOTE: The https://universal-blue.org/[Universal Blue] project creates operating 
 . Finally, install the drivers:
 
  # rpm-ostree install kmod-nvidia xorg-x11-drv-nvidia
- # rpm-ostree kargs --append=rd.driver.blacklist=nouveau --append=modprobe.blacklist=nouveau --append=nvidia-drm.modeset=1
+ # rpm-ostree kargs --append=rd.driver.blacklist=nouveau --append=modprobe.blacklist=nouveau --append=nvidia-drm.modeset=1 --append=initcall_blacklist=simpledrm_platform_driver_init
  # systemctl reboot
 
 NOTE: When using Secure Boot, the locally installed NVIDIA drivers have to be signed with a local key that is enrolled using `mokutil`. See the https://github.com/fedora-silverblue/issue-tracker/issues/499[fedora-silverblue#499] issue for more details.


### PR DESCRIPTION
Adds `initcall_blacklist=simpledrm_platform_driver_init` to kargs to keep up to date with https://rpmfusion.org/Howto/NVIDIA#OSTree_.28Silverblue.2FKinoite.2Fetc.29

This is needed for LUKS password screen (https://github.com/fedora-silverblue/issue-tracker/issues/477), without it booting the system gets stuck on some NVidia GPUs.