### PR TITLE
Update Firefox tip with new Firefox desktop file name

### DIFF
--- a/modules/ROOT/pages/tips-and-tricks.adoc
+++ b/modules/ROOT/pages/tips-and-tricks.adoc
@@ -6,7 +6,7 @@ If you're using another browser than the one installed by default (Firefox) then
 
 ```
 $ sudo mkdir -p /usr/local/share/applications/
-$ sudo cp /usr/share/applications/firefox.desktop /usr/local/share/applications/
+$ sudo cp /usr/share/applications/org.mozilla.firefox.desktop /usr/local/share/applications/
 $ sudo sed -i "2a\\NotShowIn=GNOME;KDE" /usr/local/share/applications/firefox.desktop
 $ sudo update-desktop-database /usr/local/share/applications/
 ```


### PR DESCRIPTION
https://fedoraproject.org/wiki/Changes/RenameFirefoxDesktopFile has changed the file name of the `.desktop` file, so it needs to be updated.

Coming here [because this change has unfortunate consequences](https://discussion.fedoraproject.org/t/after-fedora-40-upgrade-desktop-icon-for-default-base-image-firefox-is-missing-in-dash/114934) for me and I need to adapt these steps to get back a link to the rpm (non-flatpak) Firefox.