### PR TITLE
RPM Fusion: Add note on updates page

### DIFF
--- a/modules/ROOT/pages/tips-and-tricks.adoc
+++ b/modules/ROOT/pages/tips-and-tricks.adoc
@@ -38,6 +38,8 @@ Fedora recommends the use of free and open source software and avoidance of soft
 
 Users may want to take advantage of the non-free software that is made available via the https://rpmfusion.org/[RPM Fusion] repos in order to use the proprietary NVIDIA drivers, multimedia codecs, or other software not distributed as part of Fedora.
 
+=== First installation
+
 The first time you install the RPM Fusion repos, you need to install the versioned RPMs:
 
     $ sudo rpm-ostree install \
@@ -45,6 +47,9 @@ The first time you install the RPM Fusion repos, you need to install the version
         https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
     $ reboot
 
+Then continue with the next section to prepare your system for major Fedora updates.
+
+=== Major Fedora updates
 
 Once you have rebooted into the new deployment, you can run the following command to remove the “lock” on the versioned packages that were installed previously.
 This will enable the RPM Fusion repos to be automatically updated and versioned correctly across major Fedora version rebases:

--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -65,6 +65,8 @@ NOTE: Currently, the default remote for {variant-name} {version-stable} is named
 
 The process is very similar to a system update: the new OS is downloaded and installed in the background, and you just boot into it when it is ready.
 
+NOTE: If you are using the RPM Fusion repositories and are having issues during major updates, see the xref:tips-and-tricks.adoc#_enabling_rpm_fusion_repos[Enabling RPM Fusion repos] section.
+
 [[rebasing]]
 == Rebasing to another Atomic Desktop
 

--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -65,6 +65,9 @@ NOTE: Currently, the default remote for {variant-name} {version-stable} is named
 
 The process is very similar to a system update: the new OS is downloaded and installed in the background, and you just boot into it when it is ready.
 
+[[rebasing]]
+== Rebasing to another Atomic Desktop
+
 Additionally, you can choose to rebase to a different variant of Fedora Atomic, like for example {alternative-name}.
 {alternative-name} is similar to {variant-name}, except for the fact that it uses the {alternative-desktop} instead of the default {variant-desktop}.
 
@@ -73,7 +76,7 @@ Because the two system images are isolated from eachother, the two desktop envir
 All of your flatpak apps and /home files will stay persistent between rebases.
 Same applies for testing out the bleeding-edge version of {variant-name}, which is Rawhide.
 
-If you decide to rebase, make sure to xref:faq.adoc#pinning[pin] your current deployment, so you don't accidentaly lose it (by default, only the two most recent deployments are kept).
+If you decide to rebase, make sure to xref:faq.adoc#pinning[pin] your current deployment, so you don't accidentally lose it (by default, only the two most recent deployments are kept).
 
 [[rolling-back]]
 == Rolling back


### PR DESCRIPTION
updates-upgrades-rollbacks: Split rebase into a section

---

RPM Fusion: Add note on updates page

- Link to the RPM Fusion instructions in tips & tricks from the updates
  page in the major updates section.
- split the RPM Fusion instruction in two sections to make it clear
  which parts is needed for what.