### PR TITLE
Replace sudo $EDITOR with sudoedit

### DIFF
--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -89,7 +89,7 @@ The following is a full example for setting up the Tailscale repo:
 
 . Replace the `gpgkey=` URL in the repo config by the path the GPG keys:
 
- $ sudo $EDITOR /etc/yum.repos.d/tailscale.repo
+ $ sudoedit /etc/yum.repos.d/tailscale.repo
  $ cat /etc/yum.repos.d/tailscale.repo
  [tailscale-stable]
  name=Tailscale stable


### PR DESCRIPTION
Small change to replace the use of `sudo $EDITOR` with `sudoedit`. Best practices are generally to avoid running a fully interactive program like an editor as root. It's much safer to use sudoedit which will run the editor as the user instead. 